### PR TITLE
OY-5658: näytä kieli myös Perusopetuksen oppiaineen oppimäärä -suorituksessa

### DIFF
--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/ui/EntityToUIConverter.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/ui/EntityToUIConverter.scala
@@ -25,6 +25,14 @@ object EntityToUIConverter {
 
   private val oppiaineOrder: Map[String, Int] = UIService.NAYTETTAVAT_OPPIAINEET.zipWithIndex.toMap
 
+  private def getVieraanKielenNimi(kieli: Option[Koodi], asiointiKieli: String, koodistoProvider: KoodistoProvider): Option[String] =
+    kieli.flatMap(k => koodistoProvider.haeKoodisto(UIService.KOODISTO_KIELIVALIKOIMA).get(k.arvo)
+      .flatMap(_.metadata.find(_.kieli.equalsIgnoreCase(asiointiKieli)).map(_.nimi)))
+
+  private def getAidinkielenNimi(kieli: Option[Koodi], asiointiKieli: String, koodistoProvider: KoodistoProvider): Option[String] =
+    kieli.flatMap(k => koodistoProvider.haeKoodisto(KOODISTO_OPPIAINE_AIDINKIELI_JA_KIRJALLISUUS).get(k.arvo)
+      .flatMap(_.metadata.find(_.kieli.equalsIgnoreCase(asiointiKieli)).map(_.nimi)))
+
   private def filterAndSortOppiaineet(oppiaineet: Iterable[PerusopetuksenOppiaineUI]): List[PerusopetuksenOppiaineUI] =
     oppiaineet
       .filter(a => oppiaineOrder.contains(a.koodi))
@@ -403,17 +411,12 @@ object EntityToUIConverter {
 
   def getDiaTutkinto(opiskeluoikeudet: Set[Opiskeluoikeus], koodistoProvider: KoodistoProvider): Option[DIATutkintoUI] = {
     def toDiaOppiaineUI(oppiaine: DIAOppiaine) = {
-      def getVieraanKielenNimi(kieli: Option[Koodi], asiointiKieli: String): Option[String] =
-        kieli
-          .flatMap(kieli => koodistoProvider.haeKoodisto(UIService.KOODISTO_KIELIVALIKOIMA)
-          .get(kieli.arvo)
-            .flatMap(koodi => koodi.metadata.find(m => m.kieli.equalsIgnoreCase(asiointiKieli)).map(m => m.nimi)))
       DIAOppiaineUI(
         tunniste = oppiaine.tunniste,
         nimi = DIAOppiaineNimiUI(
-          fi = oppiaine.nimi.fi.map(n => n + getVieraanKielenNimi(oppiaine.kieli, "fi").map(k => ", " + k).getOrElse("")).toJava,
-          sv = oppiaine.nimi.sv.map(n => n + getVieraanKielenNimi(oppiaine.kieli, "sv").map(k => ", " + k).getOrElse("")).toJava,
-          en = oppiaine.nimi.en.map(n => n + getVieraanKielenNimi(oppiaine.kieli, "en").map(k => ", " + k).getOrElse("")).toJava,
+          fi = oppiaine.nimi.fi.map(n => n + getVieraanKielenNimi(oppiaine.kieli, "fi", koodistoProvider).map(k => ", " + k).getOrElse("")).toJava,
+          sv = oppiaine.nimi.sv.map(n => n + getVieraanKielenNimi(oppiaine.kieli, "sv", koodistoProvider).map(k => ", " + k).getOrElse("")).toJava,
+          en = oppiaine.nimi.en.map(n => n + getVieraanKielenNimi(oppiaine.kieli, "en", koodistoProvider).map(k => ", " + k).getOrElse("")).toJava,
         ),
         laajuus = oppiaine.laajuus.map(_.arvo).toJava,
         kirjallinen = oppiaine.kirjallinenKoe.map(_.arvosana.arvosana.arvo).toJava,
@@ -904,12 +907,6 @@ object EntityToUIConverter {
         }).toList
 
   def getPerusopetuksenOppimaarat(opiskeluoikeudet: Set[Opiskeluoikeus], koodistoProvider: KoodistoProvider): List[PerusopetuksenOppimaaraUI] =
-    def getVieraanKielenNimi(kieli: Option[Koodi], asiointiKieli: String): Option[String] =
-      kieli.flatMap(kieli => koodistoProvider.haeKoodisto(UIService.KOODISTO_KIELIVALIKOIMA).get(kieli.arvo).flatMap(koodi => koodi.metadata.find(m => m.kieli.equalsIgnoreCase(asiointiKieli)).map(m => m.nimi)))
-
-    def getAidinkielenNimi(kieli: Option[Koodi], asiointiKieli: String): Option[String] =
-      kieli.flatMap(kieli => koodistoProvider.haeKoodisto(KOODISTO_OPPIAINE_AIDINKIELI_JA_KIRJALLISUUS).get(kieli.arvo).flatMap(koodi => koodi.metadata.find(m => m.kieli.equalsIgnoreCase(asiointiKieli)).map(m => m.nimi)))
-
     opiskeluoikeudet
       .collect { case oo: PerusopetuksenOpiskeluoikeus => oo }
       .flatMap(_.suoritukset)
@@ -948,8 +945,8 @@ object EntityToUIConverter {
             val omanAineenOppiaineet: Seq[PerusopetuksenOppiaineUI] =
               (if (onValmis) om.aineet else Seq.empty).map(a => {
                 def getLisatieto(asiointiKieli: String): Option[String] =
-                  if (a.koodi.arvo == "AI") getAidinkielenNimi(a.kieli, asiointiKieli)
-                  else getVieraanKielenNimi(a.kieli, asiointiKieli)
+                  if (a.koodi.arvo == "AI") getAidinkielenNimi(a.kieli, asiointiKieli, koodistoProvider)
+                  else getVieraanKielenNimi(a.kieli, asiointiKieli, koodistoProvider)
                 PerusopetuksenOppiaineUI(
                   tunniste = a.tunniste,
                   koodi = a.koodi.arvo,
@@ -975,7 +972,7 @@ object EntityToUIConverter {
   def getPerusopetuksenOppimaarat78Luokkalaiset(opiskeluoikeudet: Set[Opiskeluoikeus]): Option[PerusopetuksenOppimaara78Luokkalaiset] =
     None
 
-  def getPerusopetuksenOppiaineenOppimaarat(opiskeluoikeudet: Set[Opiskeluoikeus]): List[PerusopetuksenOppiaineenOppimaaratUI] = {
+  def getPerusopetuksenOppiaineenOppimaarat(opiskeluoikeudet: Set[Opiskeluoikeus], koodistoProvider: KoodistoProvider): List[PerusopetuksenOppiaineenOppimaaratUI] = {
     opiskeluoikeudet
       .collect { case oo: PerusopetuksenOpiskeluoikeus => oo }
       .flatMap(_.suoritukset)
@@ -983,13 +980,16 @@ object EntityToUIConverter {
       .map(oppiaineidenSuoritus => {
         val oppiaineet: Set[PerusopetuksenOppiaineUI] =
           oppiaineidenSuoritus.aineet.map(oppiaine => {
+            def getLisatieto(asiointiKieli: String): Option[String] =
+              if (oppiaine.koodi.arvo == "AI") getAidinkielenNimi(oppiaine.kieli, asiointiKieli, koodistoProvider)
+              else getVieraanKielenNimi(oppiaine.kieli, asiointiKieli, koodistoProvider)
             PerusopetuksenOppiaineUI(
               tunniste = oppiaine.tunniste,
               koodi = oppiaine.koodi.arvo,
               nimi = PerusopetuksenOppiaineNimi(
-                oppiaine.nimi.fi.toJava,
-                oppiaine.nimi.sv.toJava,
-                oppiaine.nimi.en.toJava
+                fi = oppiaine.nimi.fi.map(n => n + getLisatieto("fi").map(k => ", " + k).getOrElse("")).toJava,
+                sv = oppiaine.nimi.sv.map(n => n + getLisatieto("sv").map(k => ", " + k).getOrElse("")).toJava,
+                en = oppiaine.nimi.en.map(n => n + getLisatieto("en").map(k => ", " + k).getOrElse("")).toJava,
               ),
               kieli = java.util.Optional.ofNullable(oppiaine.kieli.map(_.arvo).orNull),
               arvosana = Optional.of(oppiaine.arvosana.arvo),
@@ -1096,7 +1096,7 @@ object EntityToUIConverter {
         vapaaSivistystyoKoulutukset =               getVapaaSivistystyoKoulutukset(opiskeluoikeudet).asJava,
         perusopetuksenOppimaarat =                  getPerusopetuksenOppimaarat(opiskeluoikeudet, koodistoProvider).asJava,
         perusopetuksenOppimaara78Luokkalaiset =     getPerusopetuksenOppimaarat78Luokkalaiset(opiskeluoikeudet).toJava,
-        perusopetuksenOppiaineenOppimaarat =        getPerusopetuksenOppiaineenOppimaarat(opiskeluoikeudet).asJava
+        perusopetuksenOppiaineenOppimaarat =        getPerusopetuksenOppiaineenOppimaarat(opiskeluoikeudet, koodistoProvider).asJava
       )
   }
 

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/ui/EntityToUIConverterTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/ui/EntityToUIConverterTest.scala
@@ -2,7 +2,7 @@ package fi.oph.suorituspalvelu.ui
 
 import fi.oph.suorituspalvelu.business.LahtokouluTyyppi.{TELMA, TUVA, VAPAA_SIVISTYSTYO}
 import fi.oph.suorituspalvelu.business.SuoritusTila.VALMIS
-import fi.oph.suorituspalvelu.business.{AmmatillinenOpiskeluoikeus, AmmatillinenPerustutkinto, AmmatillisenTutkinnonOsa, AmmatillisenTutkinnonOsaAlue, AmmattiTutkinto, Arvosana, EBTutkinto, ErikoisAmmattiTutkinto, GeneerinenOpiskeluoikeus, IBArvosana, IBLaajuus, IBOppiaineRyhma, IBOppiaineSuoritus, IBTutkinto, KKOpintosuoritus, KKOpiskeluoikeus, KKOpiskeluoikeusTila, KKTutkinto, Koe, Koodi, Laajuus, Lahtokoulu, LukionOppimaara, Opiskeluoikeus, Oppilaitos, PerusopetuksenOpiskeluoikeus, PerusopetuksenOppiaine, PerusopetuksenOppimaara, PerusopetuksenYksilollistaminen, Telma, Tuva, VapaaSivistystyo, YOOpiskeluoikeus, YOTutkinto}
+import fi.oph.suorituspalvelu.business.{AmmatillinenOpiskeluoikeus, AmmatillinenPerustutkinto, AmmatillisenTutkinnonOsa, AmmatillisenTutkinnonOsaAlue, AmmattiTutkinto, Arvosana, EBTutkinto, ErikoisAmmattiTutkinto, GeneerinenOpiskeluoikeus, IBArvosana, IBLaajuus, IBOppiaineRyhma, IBOppiaineSuoritus, IBTutkinto, KKOpintosuoritus, KKOpiskeluoikeus, KKOpiskeluoikeusTila, KKTutkinto, Koe, Koodi, Laajuus, Lahtokoulu, LukionOppimaara, Opiskeluoikeus, Oppilaitos, PerusopetuksenOpiskeluoikeus, PerusopetuksenOppiaine, PerusopetuksenOppimaara, PerusopetuksenOppimaaranOppiaineidenSuoritus, PerusopetuksenYksilollistaminen, Telma, Tuva, VapaaSivistystyo, YOOpiskeluoikeus, YOTutkinto}
 import fi.oph.suorituspalvelu.integration.client.{KoodiMetadata, Koodisto, Organisaatio, OrganisaatioNimi}
 import fi.oph.suorituspalvelu.parsing.koski.Kielistetty
 import fi.oph.suorituspalvelu.parsing.virta.VirtaToSuoritusConverter
@@ -1240,6 +1240,134 @@ class EntityToUIConverterTest {
       en = Optional.of("Mathematics: Analysis and Approaches HL")
     ), suoritus2.nimi)
     Assertions.assertEquals(Optional.of("7"), suoritus2.predictedGrade)
+  }
+
+  private def oppiaineenOppimaaraOpiskeluoikeus(aineet: Set[PerusopetuksenOppiaine]): PerusopetuksenOpiskeluoikeus =
+    PerusopetuksenOpiskeluoikeus(
+      tunniste = UUID.randomUUID(),
+      oid = Some("1.2.3"),
+      oppilaitosOid = "1.2.246.562.10.11168857016",
+      suoritukset = Set(PerusopetuksenOppimaaranOppiaineidenSuoritus(
+        tunniste = UUID.randomUUID(),
+        versioTunniste = None,
+        oppilaitos = Oppilaitos(Kielistetty(Some("Keltinmäen koulu"), None, None), "1.2.246.562.10.11168857016"),
+        koskiTila = Koodi("valmistunut", "", None),
+        supaTila = fi.oph.suorituspalvelu.business.SuoritusTila.VALMIS,
+        suoritusKieli = Koodi("FI", "kieli", Some(1)),
+        aloitusPaivamaara = Some(LocalDate.parse("2015-01-01")),
+        vahvistusPaivamaara = Some(LocalDate.parse("2016-06-01")),
+        aineet = aineet,
+        syotetty = false
+      )),
+      lisatiedot = None,
+      tila = fi.oph.suorituspalvelu.business.SuoritusTila.VALMIS,
+      jaksot = List.empty
+    )
+
+  @Test def testConvertPerusopetuksenOppiaineenOppimaaraVieraskieliOppiaine(): Unit = {
+    val a1Tunniste = UUID.randomUUID()
+    val aineet = Set(PerusopetuksenOppiaine(
+      tunniste = a1Tunniste,
+      nimi = Kielistetty(Some("A1-kieli"), Some("A1-språk"), Some("A1 language")),
+      koodi = Koodi("A1", "koskioppiaineetyleissivistava", Some(1)),
+      arvosana = Koodi("9", "arviointiasteikkoyleissivistava", Some(1)),
+      kieli = Some(Koodi("EN", "kielivalikoima", Some(1))),
+      pakollinen = true,
+      yksilollistetty = Some(false),
+      rajattu = Some(false)
+    ))
+
+    val koodistoProvider = new KoodistoProvider {
+      override def haeKoodisto(koodisto: String): Map[String, fi.oph.suorituspalvelu.integration.client.Koodi] =
+        if (koodisto == UIService.KOODISTO_KIELIVALIKOIMA)
+          Map("EN" -> fi.oph.suorituspalvelu.integration.client.Koodi("EN", Koodisto(UIService.KOODISTO_KIELIVALIKOIMA), List(
+            KoodiMetadata("FI", "englanti"),
+            KoodiMetadata("SV", "engelska"),
+            KoodiMetadata("EN", "English"),
+          )))
+        else Map.empty
+    }
+
+    val result = EntityToUIConverter.getOppijanTiedot(
+      None, None, None, "1.2.3", "2.3.4", None,
+      Set(oppiaineenOppimaaraOpiskeluoikeus(aineet)),
+      DUMMY_ORGANISAATIOPROVIDER, koodistoProvider
+    ).perusopetuksenOppiaineenOppimaarat
+
+    Assertions.assertEquals(1, result.size())
+    val oppiaineet = result.get(0).oppiaineet.asScala
+    val a1 = oppiaineet.find(_.tunniste == a1Tunniste).get
+    Assertions.assertEquals(Optional.of("A1-kieli, englanti"), a1.nimi.fi)
+    Assertions.assertEquals(Optional.of("A1-språk, engelska"), a1.nimi.sv)
+    Assertions.assertEquals(Optional.of("A1 language, English"), a1.nimi.en)
+    Assertions.assertEquals(Optional.of("EN"), a1.kieli)
+  }
+
+  @Test def testConvertPerusopetuksenOppiaineenOppimaaraAidinkieli(): Unit = {
+    val aiTunniste = UUID.randomUUID()
+    val aineet = Set(PerusopetuksenOppiaine(
+      tunniste = aiTunniste,
+      nimi = Kielistetty(Some("Äidinkieli ja kirjallisuus"), Some("Modersmål och litteratur"), Some("Native language and literature")),
+      koodi = Koodi("AI", "koskioppiaineetyleissivistava", Some(1)),
+      arvosana = Koodi("9", "arviointiasteikkoyleissivistava", Some(1)),
+      kieli = Some(Koodi("AI1", "oppiaineaidinkielijakirjallisuus", Some(1))),
+      pakollinen = true,
+      yksilollistetty = Some(false),
+      rajattu = Some(false)
+    ))
+
+    val koodistoProvider = new KoodistoProvider {
+      override def haeKoodisto(koodisto: String): Map[String, fi.oph.suorituspalvelu.integration.client.Koodi] =
+        if (koodisto == UIService.KOODISTO_OPPIAINE_AIDINKIELI_JA_KIRJALLISUUS)
+          Map("AI1" -> fi.oph.suorituspalvelu.integration.client.Koodi("AI1", Koodisto(UIService.KOODISTO_OPPIAINE_AIDINKIELI_JA_KIRJALLISUUS), List(
+            KoodiMetadata("FI", "Suomen kieli ja kirjallisuus"),
+            KoodiMetadata("SV", "Finska språket och litteratur"),
+            KoodiMetadata("EN", "Finnish language and literature"),
+          )))
+        else Map.empty
+    }
+
+    val result = EntityToUIConverter.getOppijanTiedot(
+      None, None, None, "1.2.3", "2.3.4", None,
+      Set(oppiaineenOppimaaraOpiskeluoikeus(aineet)),
+      DUMMY_ORGANISAATIOPROVIDER, koodistoProvider
+    ).perusopetuksenOppiaineenOppimaarat
+
+    Assertions.assertEquals(1, result.size())
+    val oppiaineet = result.get(0).oppiaineet.asScala
+    val ai = oppiaineet.find(_.tunniste == aiTunniste).get
+    Assertions.assertEquals(Optional.of("Äidinkieli ja kirjallisuus, Suomen kieli ja kirjallisuus"), ai.nimi.fi)
+    Assertions.assertEquals(Optional.of("Modersmål och litteratur, Finska språket och litteratur"), ai.nimi.sv)
+    Assertions.assertEquals(Optional.of("Native language and literature, Finnish language and literature"), ai.nimi.en)
+    Assertions.assertEquals(Optional.of("AI1"), ai.kieli)
+  }
+
+  @Test def testConvertPerusopetuksenOppiaineenOppimaaraIlmanKielta(): Unit = {
+    val maTunniste = UUID.randomUUID()
+    val aineet = Set(PerusopetuksenOppiaine(
+      tunniste = maTunniste,
+      nimi = Kielistetty(Some("Matematiikka"), Some("Matematik"), Some("Mathematics")),
+      koodi = Koodi("MA", "koskioppiaineetyleissivistava", Some(1)),
+      arvosana = Koodi("8", "arviointiasteikkoyleissivistava", Some(1)),
+      kieli = None,
+      pakollinen = true,
+      yksilollistetty = Some(false),
+      rajattu = Some(false)
+    ))
+
+    val result = EntityToUIConverter.getOppijanTiedot(
+      None, None, None, "1.2.3", "2.3.4", None,
+      Set(oppiaineenOppimaaraOpiskeluoikeus(aineet)),
+      DUMMY_ORGANISAATIOPROVIDER, DUMMY_KOODISTOPROVIDER
+    ).perusopetuksenOppiaineenOppimaarat
+
+    Assertions.assertEquals(1, result.size())
+    val oppiaineet = result.get(0).oppiaineet.asScala
+    val ma = oppiaineet.find(_.tunniste == maTunniste).get
+    Assertions.assertEquals(Optional.of("Matematiikka"), ma.nimi.fi)
+    Assertions.assertEquals(Optional.of("Matematik"), ma.nimi.sv)
+    Assertions.assertEquals(Optional.of("Mathematics"), ma.nimi.en)
+    Assertions.assertEquals(Optional.empty(), ma.kieli)
   }
 
   @Test def testConvertIBTutkintoIlmanRyhmaa(): Unit = {


### PR DESCRIPTION
`getPerusopetuksenOppimaarat` liitti jo koodistosta haetun kielen nimen oppiainesuorituksen nimeen (esim. "A1-kieli, englanti"), mutta `getPerusopetuksenOppiaineenOppimaarat` palautti nimen ilman kielitietoa. Tämä PR korjaa epäjohdonmukaisuuden.

## Muutokset

- `getPerusopetuksenOppiaineenOppimaarat` rakentaa nyt nimikentän samalla tavalla kuin `getPerusopetuksenOppimaarat`: vieraan kielen nimi haetaan `kielivalikoima`-koodistosta ja äidinkielen nimi `oppiaineaidinkielijakirjallisuus`-koodistosta, ja lisätään oppiainesuorituksen nimeen kaikille kielivarianteille (fi/sv/en).

- Refaktoroitu `getVieraanKielenNimi` ja `getAidinkielenNimi` objektitason yksityisiksi metodeiksi. Identtiset paikalliset funktiot oli kopioitu kolmeen paikkaan (`getDiaTutkinto`, `getPerusopetuksenOppimaarat`, `getPerusopetuksenOppiaineenOppimaarat`).

## Testit

Lisätty kolme yksikkötestiä `EntityToUIConverterTest`iin:
- vieraskielinen oppiaine (A1 + EN) — tarkistaa fi/sv/en-nimikentät
- äidinkieli (AI + AI1) — tarkistaa fi/sv/en-nimikentät
- oppiaine ilman kieltä (MA) — varmistaa, ettei kieltä liitetä