### PR TITLE
OY-5664: retryjä onr-kutsuun

### DIFF
--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/HakukelpoisuusService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/HakukelpoisuusService.scala
@@ -2,6 +2,7 @@ package fi.oph.suorituspalvelu.service
 
 import fi.oph.suorituspalvelu.business.{AmmatillinenOpiskeluoikeus, GeneerinenOpiskeluoikeus, KantaOperaatiot, Opiskeluoikeus, SuoritusTila, YOOpiskeluoikeus}
 import fi.oph.suorituspalvelu.integration.OnrIntegration
+import fi.oph.suorituspalvelu.integration.client.RetryConfig
 import fi.oph.suorituspalvelu.parsing.OpiskeluoikeusParsingService
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -61,6 +62,8 @@ class HakukelpoisuusService {
   @Autowired val opiskeluoikeusParsingService: OpiskeluoikeusParsingService = null
 
   @Autowired val onrIntegration: OnrIntegration = null
+
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
 
   def haeSupaTiedot(personOid: String): Seq[Opiskeluoikeus] = {
     val allOidsForPerson = Await.result(onrIntegration.getAliasesForPersonOids(Set(personOid)), 10.seconds).allOids

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/HakukelpoisuusService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/HakukelpoisuusService.scala
@@ -63,10 +63,10 @@ class HakukelpoisuusService {
 
   @Autowired val onrIntegration: OnrIntegration = null
 
-  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 1)
 
   def haeSupaTiedot(personOid: String): Seq[Opiskeluoikeus] = {
-    val allOidsForPerson = Await.result(onrIntegration.getAliasesForPersonOids(Set(personOid)), 10.seconds).allOids
+    val allOidsForPerson = Await.result(onrIntegration.getAliasesForPersonOids(Set(personOid)), 65.seconds).allOids
     allOidsForPerson.flatMap(oid => opiskeluoikeusParsingService.haeSuoritukset(oid).values.flatten).toSeq
   }
 

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/LahtokoulutService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/LahtokoulutService.scala
@@ -3,6 +3,7 @@ package fi.oph.suorituspalvelu.service
 import fi.oph.suorituspalvelu.business.LahtokouluTyyppi.*
 import fi.oph.suorituspalvelu.business.KantaOperaatiot
 import fi.oph.suorituspalvelu.integration.OnrIntegration
+import fi.oph.suorituspalvelu.integration.client.RetryConfig
 import fi.oph.suorituspalvelu.parsing.koski.KoskiUtil
 import fi.oph.suorituspalvelu.resource.api.LahtokouluAuthorization
 import org.slf4j.LoggerFactory
@@ -21,6 +22,8 @@ class LahtokoulutService {
   @Autowired val kantaOperaatiot: KantaOperaatiot = null
 
   @Autowired val onrIntegration: OnrIntegration = null
+
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
 
   val ONR_TIMEOUT = 10.seconds
   

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/LahtokoulutService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/LahtokoulutService.scala
@@ -23,10 +23,8 @@ class LahtokoulutService {
 
   @Autowired val onrIntegration: OnrIntegration = null
 
-  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 1)
 
-  val ONR_TIMEOUT = 10.seconds
-  
   def haeLuokat(oppilaitosOid: String, valmistumisVuosi: Int): Set[String] = {
     kantaOperaatiot.haeLuokat(None, oppilaitosOid, valmistumisVuosi, None)
   }
@@ -40,7 +38,7 @@ class LahtokoulutService {
         .map(aliakset => {
           henkilotJaLuokat.flatMap((h, l) => aliakset.allOidsByQueriedOids(h).map(oid => (oid, l)))
         })
-      Await.result(r, 30.seconds)
+      Await.result(r, 65.seconds)
   }
 
   def haeLahtokouluAuthorizations(henkiloOid: String): Seq[LahtokouluAuthorization] = {
@@ -51,6 +49,6 @@ class LahtokoulutService {
         KoskiUtil.luoLahtokouluAuthorizations(lahtokoulut.toSeq)
       })
 
-    Await.result(r, 30.seconds)
+    Await.result(r, 65.seconds)
   }
 }

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/UIService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/UIService.scala
@@ -2,7 +2,7 @@ package fi.oph.suorituspalvelu.service
 
 import fi.oph.suorituspalvelu.business.LahtokouluTyyppi.SUPAN_KAYTTOLIITTYMASSA_NAYTETTAVAT
 import fi.oph.suorituspalvelu.business.KantaOperaatiot
-import fi.oph.suorituspalvelu.integration.client.{AtaruPermissionRequest, HakemuspalveluClientImpl, VTSClient, VanhaTarjontaClient, Vastaanotot}
+import fi.oph.suorituspalvelu.integration.client.{AtaruPermissionRequest, HakemuspalveluClientImpl, RetryConfig, VTSClient, VanhaTarjontaClient, Vastaanotot}
 import fi.oph.suorituspalvelu.integration.{OnrIntegration, OnrMasterHenkilo}
 import fi.oph.suorituspalvelu.parsing.OpiskeluoikeusParsingService
 import fi.oph.suorituspalvelu.parsing.koski.KoskiUtil
@@ -136,6 +136,8 @@ class UIService {
   @Autowired val opiskeluoikeusParsingService: OpiskeluoikeusParsingService = null
 
   @Autowired val onrIntegration: OnrIntegration = null
+
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
 
   @Autowired val hakemuspalveluClient: HakemuspalveluClientImpl = null
 

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/UIService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/UIService.scala
@@ -137,7 +137,7 @@ class UIService {
 
   @Autowired val onrIntegration: OnrIntegration = null
 
-  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 0)
 
   @Autowired val hakemuspalveluClient: HakemuspalveluClientImpl = null
 
@@ -153,7 +153,7 @@ class UIService {
 
   @Autowired val vtsClient: VTSClient = null
 
-  val ONR_TIMEOUT = 10.seconds
+  val ONR_TIMEOUT = 65.seconds
   val VTS_TIMEOUT = 30.seconds
 
   def haeOppilaitoksetJoihinOikeudet(oppilaitosOids: Set[String]): Set[Oppilaitos] = {
@@ -324,7 +324,7 @@ class UIService {
   def haeYliajonMuutosHistoria(personOid: String, hakuOid: String, avain: String): Seq[YliajonMuutosUI] = {
     val muutokset = this.kantaOperaatiot.haeYliajoMuutokset(personOid, hakuOid, avain)
     val virkailijaOidit = muutokset.map(_.virkailijaOid).toSet
-    val virkailijat = Await.result(onrIntegration.getPerustiedotByPersonOids(virkailijaOidit), 10.seconds).map(h => h.oidHenkilo -> h).toMap
+    val virkailijat = Await.result(onrIntegration.getPerustiedotByPersonOids(virkailijaOidit), 65.seconds).map(h => h.oidHenkilo -> h).toMap
     muutokset.map(muutos => YliajonMuutosUI(muutos.arvo.toJava, muutos.luotu, virkailijat.get(muutos.virkailijaOid).map(v => (v.etunimet.getOrElse("") + " " + v.sukunimi.getOrElse("")).trim).toJava, muutos.selite))
   }
 }

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/ValintaDataService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/ValintaDataService.scala
@@ -2,7 +2,7 @@ package fi.oph.suorituspalvelu.service
 
 import fi.oph.suorituspalvelu.business.{AvainArvoYliajo, KantaOperaatiot, Opiskeluoikeus}
 import fi.oph.suorituspalvelu.integration.{HakukohderyhmaIntegration, OnrIntegration, TarjontaIntegration}
-import fi.oph.suorituspalvelu.integration.client.{AtaruValintalaskentaHakemus, HakemuspalveluClient, KoutaHaku, OhjausparametritClient}
+import fi.oph.suorituspalvelu.integration.client.{AtaruValintalaskentaHakemus, HakemuspalveluClient, KoutaHaku, OhjausparametritClient, RetryConfig}
 import fi.oph.suorituspalvelu.parsing.OpiskeluoikeusParsingService
 import fi.oph.suorituspalvelu.mankeli.{AvainArvoConstants, AvainArvoContainer, AvainArvoConverter, AvainArvoConverterResults, AvainMetatiedotDTO, ConvertedAtaruHakemus, EnsikertalaisuusService, HarkinnanvaraisuusService, ValintalaskentaHakutoive, YoMetadataConverter}
 import fi.oph.suorituspalvelu.resource.api.{ValintalaskentaApiAvainArvo, ValintalaskentaApiAvainMetatiedotDTO, ValintalaskentaApiHakemus, ValintalaskentaApiHakutoive}
@@ -45,6 +45,8 @@ class ValintaDataService {
   @Autowired val opiskeluoikeusParsingService: OpiskeluoikeusParsingService = null
 
   @Autowired val onrIntegration: OnrIntegration = null
+
+  implicit val onrRetryConfig: RetryConfig = RetryConfig()
 
   @Autowired val hakemuspalveluClient: HakemuspalveluClient = null
 

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/VirtaService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/VirtaService.scala
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.github.kagkarlsson.scheduler.Scheduler
 import com.github.kagkarlsson.scheduler.task.{FailureHandler, TaskDescriptor}
 import com.github.kagkarlsson.scheduler.task.helper.Tasks
-import fi.oph.suorituspalvelu.business.{KantaOperaatiot, ParserVersions, Lahdejarjestelma, VersioEntiteetti}
+import fi.oph.suorituspalvelu.business.{KantaOperaatiot, Lahdejarjestelma, ParserVersions, VersioEntiteetti}
 import fi.oph.suorituspalvelu.integration.{OnrIntegration, SyncResultForHenkilo, TarjontaIntegration, Util}
-import fi.oph.suorituspalvelu.integration.client.HakemuspalveluClientImpl
+import fi.oph.suorituspalvelu.integration.client.{HakemuspalveluClientImpl, RetryConfig}
 import fi.oph.suorituspalvelu.integration.virta.VirtaClient
 import fi.oph.suorituspalvelu.jobs.{SupaJobContext, SupaScheduler}
 import fi.oph.suorituspalvelu.parsing.virta.{VirtaParser, VirtaToSuoritusConverter}
@@ -54,11 +54,12 @@ class VirtaService(scheduler: SupaScheduler, database: JdbcBackend.JdbcDatabaseD
                    @Value("${integrations.virta.cron}") cron: String) {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+  implicit val onrRetryConfig: RetryConfig = RetryConfig()
 
   val mapper = new ObjectMapper()
   mapper.registerModule(DefaultScalaModule)
 
-  final val ONR_TIMEOUT = 15.minutes
+  final val ONR_TIMEOUT = 5.minutes
   final val HAKEMUSPALVELU_TIMEOUT = 1.minutes
   final val VIRTA_TIMEOUT = 2.minutes //Timeout yhden henkilön tietojen haulle ja persistoinnille
 

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/VirtaService.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/service/VirtaService.scala
@@ -58,7 +58,7 @@ class VirtaService(scheduler: SupaScheduler, database: JdbcBackend.JdbcDatabaseD
   val mapper = new ObjectMapper()
   mapper.registerModule(DefaultScalaModule)
 
-  final val ONR_TIMEOUT = 5.minutes
+  final val ONR_TIMEOUT = 15.minutes
   final val HAKEMUSPALVELU_TIMEOUT = 1.minutes
   final val VIRTA_TIMEOUT = 2.minutes //Timeout yhden henkilön tietojen haulle ja persistoinnille
 

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/ui/UIResource.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/ui/UIResource.scala
@@ -3,6 +3,7 @@ package fi.oph.suorituspalvelu.ui
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.oph.suorituspalvelu.business.{AvainArvoYliajo, HarkinnanvaraisuusYliajo, KantaOperaatiot, Lahdejarjestelma, Opiskeluoikeus, ParserVersions}
 import fi.oph.suorituspalvelu.integration.OnrIntegration
+import fi.oph.suorituspalvelu.integration.client.RetryConfig
 import fi.oph.suorituspalvelu.mankeli.{HarkinnanvaraisuudenSyy, UseitaVahvistettujaOppimaariaException}
 import fi.oph.suorituspalvelu.parsing.koski.KoskiUtil
 import fi.oph.suorituspalvelu.parsing.virkailija.VirkailijaToSuoritusConverter
@@ -49,6 +50,8 @@ class UIResource {
   val LOG = LoggerFactory.getLogger(classOf[UIResource]);
 
   @Autowired val onrIntegration: OnrIntegration = null
+
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
 
   @Autowired val organisaatioProvider: OrganisaatioProvider = null
 

--- a/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/ui/UIResource.scala
+++ b/suorituspalvelu-service/src/main/scala/fi/oph/suorituspalvelu/ui/UIResource.scala
@@ -51,7 +51,7 @@ class UIResource {
 
   @Autowired val onrIntegration: OnrIntegration = null
 
-  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 0)
 
   @Autowired val organisaatioProvider: OrganisaatioProvider = null
 
@@ -65,7 +65,7 @@ class UIResource {
 
   @Autowired val valintaDataService: ValintaDataService = null
 
-  val ONR_TIMEOUT = 10.seconds;
+  val ONR_TIMEOUT = 65.seconds;
 
   @GetMapping(
     path = Array(UI_KAYTTAJAN_TIEDOT_PATH),

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/AutomaattinenHakukelpoisuusResourceIntegraatioTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/AutomaattinenHakukelpoisuusResourceIntegraatioTest.scala
@@ -12,6 +12,8 @@ import fi.oph.suorituspalvelu.security.{AuditOperation, SecurityConstants}
 import fi.oph.suorituspalvelu.validation.Validator
 import org.junit.jupiter.api.{Assertions, Test}
 import org.mockito.Mockito
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import fi.oph.suorituspalvelu.integration.client.RetryConfig
 import org.springframework.security.test.context.support.{WithAnonymousUser, WithMockUser}
 import org.springframework.test.context.bean.`override`.mockito.MockitoBean
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -211,7 +213,7 @@ class AutomaattinenHakukelpoisuusResourceIntegraatioTest extends BaseIntegraatio
   }
 
   private def setupMocksWithOpiskeluoikeudet(personOid: String, opiskeluoikeudet: Seq[Opiskeluoikeus]): Unit = {
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(personOid)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(personOid)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(personOid -> Set(personOid)))))
     val versio = kantaOperaatiot.tallennaJarjestelmaVersio(personOid, Lahdejarjestelma.KOSKI, Seq.empty, Seq.empty, Instant.now(), "SYOTETTY", Some(1)).get
     kantaOperaatiot.tallennaVersioonLiittyvatEntiteetit(versio, opiskeluoikeudet.toSet, Seq.empty, ParserVersions.KOSKI)

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/BaseIntegraatioTesti.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/BaseIntegraatioTesti.scala
@@ -8,7 +8,7 @@ import com.github.dockerjava.api.model.{ExposedPort, HostConfig, PortBinding, Po
 import com.github.kagkarlsson.scheduler.Scheduler
 import fi.oph.suorituspalvelu.BaseIntegraatioTesti.postgresPort
 import fi.oph.suorituspalvelu.business.KantaOperaatiot
-import fi.oph.suorituspalvelu.integration.client.{KoodiMetadata, Koodisto, Koodi}
+import fi.oph.suorituspalvelu.integration.client.{Koodi, KoodiMetadata, Koodisto, RetryConfig}
 import fi.oph.suorituspalvelu.util.KoodistoProvider
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.TestInstance.Lifecycle
@@ -58,6 +58,8 @@ object BaseIntegraatioTesti {
 class BaseIntegraatioTesti {
 
   private val LOG = LoggerFactory.getLogger(this.getClass)
+
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 0, retryDelayMillis = 1)
 
   @MockitoBean
   var koodistoProvider: KoodistoProvider = null

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/HakijatIntegraatioTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/HakijatIntegraatioTest.scala
@@ -5,6 +5,7 @@ import fi.oph.suorituspalvelu.business.Lahdejarjestelma.KOSKI
 import fi.oph.suorituspalvelu.business.SuoritusTila.VALMIS
 import fi.oph.suorituspalvelu.business.{AmmatillinenOpiskeluoikeus, AmmatillinenPerustutkinto, Koodi, Lahtokoulu, Opiskeluoikeus, ParserVersions, PerusopetuksenOpiskeluoikeus, PerusopetuksenOppimaara, Lahdejarjestelma, SuoritusTila}
 import fi.oph.suorituspalvelu.integration.client.*
+import fi.oph.suorituspalvelu.integration.client.RetryConfig
 import fi.oph.suorituspalvelu.integration.{OnrHenkiloPerustiedot, OnrIntegration, PersonOidsWithAliases}
 import fi.oph.suorituspalvelu.parsing.koski.{Kielistetty, KoskiUtil}
 import fi.oph.suorituspalvelu.resource.ApiConstants
@@ -17,6 +18,7 @@ import fi.oph.suorituspalvelu.util.OrganisaatioProvider
 import fi.oph.suorituspalvelu.validation.Validator
 import org.junit.jupiter.api.*
 import org.mockito.Mockito
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.{WithAnonymousUser, WithMockUser}
 import org.springframework.test.context.bean.`override`.mockito.MockitoBean
@@ -212,7 +214,7 @@ class LahtokoulutIntegraatioTest extends BaseIntegraatioTesti {
     ))
     kantaOperaatiot.tallennaVersioonLiittyvatEntiteetit(versio.get, opiskeluoikeudet, KoskiUtil.getLahtokouluMetadata(opiskeluoikeudet), ParserVersions.KOSKI)
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     // haetaan luokat
@@ -307,7 +309,7 @@ class LahtokoulutIntegraatioTest extends BaseIntegraatioTesti {
     kantaOperaatiot.tallennaVersioonLiittyvatEntiteetit(versio.get, opiskeluoikeudet, KoskiUtil.getLahtokouluMetadata(opiskeluoikeudet), ParserVersions.KOSKI)
 
     // mockataan onr-vastaus ja haetaan luokat
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
     val result = mvc.perform(MockMvcRequestBuilders
         .get(ApiConstants.OPISKELIJAT_LAHTOKOULUT_PATH
           .replace(ApiConstants.OPISKELIJAT_HENKILOOID_PARAM_PLACEHOLDER, oppijaNumero), ""))

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/HarkinnanvaraisuusResourceIntegraatioTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/HarkinnanvaraisuusResourceIntegraatioTest.scala
@@ -2,14 +2,14 @@ package fi.oph.suorituspalvelu
 
 import com.fasterxml.jackson.core.`type`.TypeReference
 import fi.oph.suorituspalvelu.integration.{OnrIntegration, PersonOidsWithAliases, TarjontaIntegration}
-import fi.oph.suorituspalvelu.integration.client.{AtaruValintalaskentaHakemus, DateParam, HakemuspalveluClientImpl, Hakutoive, KoutaHakukohde, Ohjausparametrit}
+import fi.oph.suorituspalvelu.integration.client.{AtaruValintalaskentaHakemus, DateParam, HakemuspalveluClientImpl, Hakutoive, KoutaHakukohde, Ohjausparametrit, RetryConfig}
 import fi.oph.suorituspalvelu.mankeli.{AvainArvoConstants, HarkinnanvaraisuudenSyy}
 import fi.oph.suorituspalvelu.resource.ApiConstants
 import fi.oph.suorituspalvelu.resource.api.{HakemustenHarkinnanvaraisuudetPayload, HarkinnanvaraisuusFailureResponse, ValintaApiHakemuksenHarkinnanvaraisuus}
 import fi.oph.suorituspalvelu.security.{AuditOperation, SecurityConstants}
 import org.springframework.test.context.bean.`override`.mockito.MockitoBean
 import org.mockito.Mockito
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.junit.jupiter.api.{Assertions, Test}
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.context.support.WithAnonymousUser
@@ -172,7 +172,7 @@ class HarkinnanvaraisuusResourceIntegraatioTest extends BaseIntegraatioTesti {
     Mockito.when(tarjontaIntegration.getOhjausparametrit(hakuOid))
       .thenReturn(ohjausparametrit)
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(personOid)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(personOid)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(personOid -> Set(personOid)))))
 
     // Execute the request
@@ -354,7 +354,7 @@ class HarkinnanvaraisuusResourceIntegraatioTest extends BaseIntegraatioTesti {
     Mockito.when(tarjontaIntegration.getOhjausparametrit(hakuOid))
       .thenReturn(ohjausparametrit)
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(personOid)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(personOid)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(personOid -> Set(personOid)))))
 
     // Execute request
@@ -463,7 +463,7 @@ class HarkinnanvaraisuusResourceIntegraatioTest extends BaseIntegraatioTesti {
     Mockito.when(tarjontaIntegration.getHakukohde(hakukohdeOid2)).thenReturn(hakukohde2)
     Mockito.when(tarjontaIntegration.getHakukohde(hakukohdeOid3)).thenReturn(hakukohde3)
     Mockito.when(tarjontaIntegration.getOhjausparametrit(hakuOid)).thenReturn(ohjausparametrit)
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(personOid)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(personOid)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(personOid -> Set(personOid)))))
 
     val result = mvc.perform(jsonPost(ApiConstants.VALINNAT_HARKINNANVARAISUUS_PATH, HakemustenHarkinnanvaraisuudetPayload(List(hakemusOid).asJava))
@@ -552,7 +552,7 @@ class HarkinnanvaraisuusResourceIntegraatioTest extends BaseIntegraatioTesti {
 
     Mockito.when(tarjontaIntegration.getHakukohde(hakukohdeOid)).thenReturn(hakukohde)
     Mockito.when(tarjontaIntegration.getOhjausparametrit(hakuOid)).thenReturn(ohjausparametrit)
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(personOid)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(personOid)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(personOid -> Set(personOid)))))
 
     // Execute request

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/OnrClientRetryTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/OnrClientRetryTest.scala
@@ -1,7 +1,7 @@
 package fi.oph.suorituspalvelu
 
 import fi.oph.suorituspalvelu.integration.NonRetriableException
-import fi.oph.suorituspalvelu.integration.client.OnrClientImpl
+import fi.oph.suorituspalvelu.integration.client.{OnrClientImpl, RetryConfig}
 import fi.vm.sade.javautils.nio.cas.CasClient
 import org.asynchttpclient.{Request, Response}
 import org.junit.jupiter.api.Assertions.*
@@ -21,10 +21,12 @@ class OnrClientRetryTest {
   private var mockCasClient: CasClient = _
   private var client: OnrClientImpl = _
 
+  private val testRetryConfig = RetryConfig(retries = 2, retryDelayMillis = 10)
+
   @BeforeEach
   def setup(): Unit = {
     mockCasClient = mock(classOf[CasClient])
-    client = new OnrClientImpl(mockCasClient, "http://localhost", onrRetries = 2, onrRetryDelayMillis = 10)
+    client = new OnrClientImpl(mockCasClient, "http://localhost")
   }
 
   private def successResponse(body: String): CompletableFuture[Response] = {
@@ -53,7 +55,7 @@ class OnrClientRetryTest {
       .thenReturn(connectionError)
       .thenReturn(successResponse("{}"))
 
-    val result = Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 10.seconds)
+    val result = Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3"), testRetryConfig), 10.seconds)
     assertEquals(Map.empty, result)
     verify(mockCasClient, times(2)).execute(any(classOf[Request]))
   }
@@ -66,7 +68,7 @@ class OnrClientRetryTest {
       .thenReturn(failFuture)
       .thenReturn(okFuture)
 
-    val result = Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 10.seconds)
+    val result = Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3"), testRetryConfig), 10.seconds)
     assertEquals(Map.empty, result)
     verify(mockCasClient, times(2)).execute(any(classOf[Request]))
   }
@@ -77,7 +79,7 @@ class OnrClientRetryTest {
     when(mockCasClient.execute(any(classOf[Request]))).thenReturn(badRequestFuture)
 
     assertThrows(classOf[NonRetriableException], () =>
-      Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 5.seconds)
+      Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3"), testRetryConfig), 5.seconds)
     )
     // 4xx ei retriata — vain yksi kutsu
     verify(mockCasClient, times(1)).execute(any(classOf[Request]))
@@ -88,7 +90,7 @@ class OnrClientRetryTest {
     when(mockCasClient.execute(any(classOf[Request]))).thenReturn(connectionError)
 
     assertThrows(classOf[RuntimeException], () =>
-      Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 10.seconds)
+      Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3"), testRetryConfig), 10.seconds)
     )
     // 1 initial attempt + 2 retries = 3 total
     verify(mockCasClient, times(3)).execute(any(classOf[Request]))
@@ -99,7 +101,7 @@ class OnrClientRetryTest {
     val okFuture = successResponse("{}")
     when(mockCasClient.execute(any(classOf[Request]))).thenReturn(okFuture)
 
-    Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 5.seconds)
+    Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3"), testRetryConfig), 5.seconds)
     verify(mockCasClient, times(1)).execute(any(classOf[Request]))
   }
 
@@ -111,7 +113,7 @@ class OnrClientRetryTest {
       .thenReturn(connectionError)
       .thenReturn(successResponse("""{"kieliKoodi":"fi"}"""))
 
-    val result = Await.result(client.getAsiointikieli("1.2.3"), 10.seconds)
+    val result = Await.result(client.getAsiointikieli("1.2.3", testRetryConfig), 10.seconds)
     assertTrue(result.isDefined)
     verify(mockCasClient, times(2)).execute(any(classOf[Request]))
   }
@@ -121,7 +123,7 @@ class OnrClientRetryTest {
     when(mockCasClient.execute(any(classOf[Request]))).thenReturn(connectionError)
 
     assertThrows(classOf[RuntimeException], () =>
-      Await.result(client.getAsiointikieli("1.2.3"), 10.seconds)
+      Await.result(client.getAsiointikieli("1.2.3", testRetryConfig), 10.seconds)
     )
     verify(mockCasClient, times(3)).execute(any(classOf[Request]))
   }
@@ -131,7 +133,7 @@ class OnrClientRetryTest {
     val notFoundFuture = errorResponse(404)
     when(mockCasClient.execute(any(classOf[Request]))).thenReturn(notFoundFuture)
 
-    val result = Await.result(client.getAsiointikieli("1.2.3"), 5.seconds)
+    val result = Await.result(client.getAsiointikieli("1.2.3", testRetryConfig), 5.seconds)
     assertFalse(result.isDefined)
     // 404 on validi vastaus, ei retriata
     verify(mockCasClient, times(1)).execute(any(classOf[Request]))
@@ -143,7 +145,7 @@ class OnrClientRetryTest {
     when(mockCasClient.execute(any(classOf[Request]))).thenReturn(forbiddenFuture)
 
     assertThrows(classOf[NonRetriableException], () =>
-      Await.result(client.getAsiointikieli("1.2.3"), 5.seconds)
+      Await.result(client.getAsiointikieli("1.2.3", testRetryConfig), 5.seconds)
     )
     // 4xx ei retriata — vain yksi kutsu
     verify(mockCasClient, times(1)).execute(any(classOf[Request]))

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/OnrClientRetryTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/OnrClientRetryTest.scala
@@ -1,0 +1,151 @@
+package fi.oph.suorituspalvelu
+
+import fi.oph.suorituspalvelu.integration.NonRetriableException
+import fi.oph.suorituspalvelu.integration.client.OnrClientImpl
+import fi.vm.sade.javautils.nio.cas.CasClient
+import org.asynchttpclient.{Request, Response}
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.api.{BeforeEach, Test, TestInstance}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.*
+
+import java.util.concurrent.CompletableFuture
+import scala.concurrent.Await
+import scala.concurrent.duration.*
+
+@Test
+@TestInstance(Lifecycle.PER_CLASS)
+class OnrClientRetryTest {
+
+  private var mockCasClient: CasClient = _
+  private var client: OnrClientImpl = _
+
+  @BeforeEach
+  def setup(): Unit = {
+    mockCasClient = mock(classOf[CasClient])
+    client = new OnrClientImpl(mockCasClient, "http://localhost", onrRetries = 2, onrRetryDelayMillis = 10)
+  }
+
+  private def successResponse(body: String): CompletableFuture[Response] = {
+    val r = mock(classOf[Response])
+    when(r.getStatusCode).thenReturn(200)
+    when(r.getResponseBody()).thenReturn(body)
+    CompletableFuture.completedFuture(r)
+  }
+
+  private def errorResponse(status: Int): CompletableFuture[Response] = {
+    val r = mock(classOf[Response])
+    when(r.getStatusCode).thenReturn(status)
+    when(r.getStatusText).thenReturn("Error")
+    when(r.getResponseBody()).thenReturn("")
+    CompletableFuture.completedFuture(r)
+  }
+
+  private def connectionError: CompletableFuture[Response] =
+    CompletableFuture.failedFuture(new RuntimeException("Connection refused"))
+
+  // --- doPost (getMasterHenkilosForPersonOids) ---
+
+  @Test
+  def testPostRetriesOnConnectionFailureThenSucceeds(): Unit = {
+    when(mockCasClient.execute(any(classOf[Request])))
+      .thenReturn(connectionError)
+      .thenReturn(successResponse("{}"))
+
+    val result = Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 10.seconds)
+    assertEquals(Map.empty, result)
+    verify(mockCasClient, times(2)).execute(any(classOf[Request]))
+  }
+
+  @Test
+  def testPostRetries5xxThenSucceeds(): Unit = {
+    val failFuture = errorResponse(503)
+    val okFuture = successResponse("{}")
+    when(mockCasClient.execute(any(classOf[Request])))
+      .thenReturn(failFuture)
+      .thenReturn(okFuture)
+
+    val result = Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 10.seconds)
+    assertEquals(Map.empty, result)
+    verify(mockCasClient, times(2)).execute(any(classOf[Request]))
+  }
+
+  @Test
+  def testPostDoesNotRetry4xxClientError(): Unit = {
+    val badRequestFuture = errorResponse(400)
+    when(mockCasClient.execute(any(classOf[Request]))).thenReturn(badRequestFuture)
+
+    assertThrows(classOf[NonRetriableException], () =>
+      Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 5.seconds)
+    )
+    // 4xx ei retriata — vain yksi kutsu
+    verify(mockCasClient, times(1)).execute(any(classOf[Request]))
+  }
+
+  @Test
+  def testPostExhaustsAllRetries(): Unit = {
+    when(mockCasClient.execute(any(classOf[Request]))).thenReturn(connectionError)
+
+    assertThrows(classOf[RuntimeException], () =>
+      Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 10.seconds)
+    )
+    // 1 initial attempt + 2 retries = 3 total
+    verify(mockCasClient, times(3)).execute(any(classOf[Request]))
+  }
+
+  @Test
+  def testPostSucceedsOnFirstAttemptWithNoRetries(): Unit = {
+    val okFuture = successResponse("{}")
+    when(mockCasClient.execute(any(classOf[Request]))).thenReturn(okFuture)
+
+    Await.result(client.getMasterHenkilosForPersonOids(Set("1.2.3")), 5.seconds)
+    verify(mockCasClient, times(1)).execute(any(classOf[Request]))
+  }
+
+  // --- doGet (getAsiointikieli) ---
+
+  @Test
+  def testGetRetriesOnConnectionFailureThenSucceeds(): Unit = {
+    when(mockCasClient.execute(any(classOf[Request])))
+      .thenReturn(connectionError)
+      .thenReturn(successResponse("""{"kieliKoodi":"fi"}"""))
+
+    val result = Await.result(client.getAsiointikieli("1.2.3"), 10.seconds)
+    assertTrue(result.isDefined)
+    verify(mockCasClient, times(2)).execute(any(classOf[Request]))
+  }
+
+  @Test
+  def testGetExhaustsAllRetries(): Unit = {
+    when(mockCasClient.execute(any(classOf[Request]))).thenReturn(connectionError)
+
+    assertThrows(classOf[RuntimeException], () =>
+      Await.result(client.getAsiointikieli("1.2.3"), 10.seconds)
+    )
+    verify(mockCasClient, times(3)).execute(any(classOf[Request]))
+  }
+
+  @Test
+  def testGetReturnsNoneFor404WithoutRetrying(): Unit = {
+    val notFoundFuture = errorResponse(404)
+    when(mockCasClient.execute(any(classOf[Request]))).thenReturn(notFoundFuture)
+
+    val result = Await.result(client.getAsiointikieli("1.2.3"), 5.seconds)
+    assertFalse(result.isDefined)
+    // 404 on validi vastaus, ei retriata
+    verify(mockCasClient, times(1)).execute(any(classOf[Request]))
+  }
+
+  @Test
+  def testGetDoesNotRetry4xxClientError(): Unit = {
+    val forbiddenFuture = errorResponse(403)
+    when(mockCasClient.execute(any(classOf[Request]))).thenReturn(forbiddenFuture)
+
+    assertThrows(classOf[NonRetriableException], () =>
+      Await.result(client.getAsiointikieli("1.2.3"), 5.seconds)
+    )
+    // 4xx ei retriata — vain yksi kutsu
+    verify(mockCasClient, times(1)).execute(any(classOf[Request]))
+  }
+}

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/OnrIntegrationTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/OnrIntegrationTest.scala
@@ -1,11 +1,12 @@
 package fi.oph.suorituspalvelu
 
 import fi.oph.suorituspalvelu.integration.{OnrIntegrationImpl, PersonOidsWithAliases}
-import fi.oph.suorituspalvelu.integration.client.{Henkiloviite, OnrClientImpl}
+import fi.oph.suorituspalvelu.integration.client.{Henkiloviite, OnrClientImpl, RetryConfig}
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.{BeforeEach, Test, TestInstance}
 import org.mockito.Mockito.*
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.MockitoAnnotations
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -18,6 +19,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 @TestInstance(Lifecycle.PER_CLASS)
 class OnrIntegrationTest {
   private var onrIntegration: OnrIntegrationImpl = _
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 10)
 
   @MockBean
   private var mockOnrClient: OnrClientImpl = _
@@ -41,7 +43,7 @@ class OnrIntegrationTest {
     val personOids = Set(personOid1, personOid2)
     val emptyViitteet = Set.empty[Henkiloviite]
 
-    when(mockOnrClient.getHenkiloviitteetForHenkilot(personOids))
+    when(mockOnrClient.getHenkiloviitteetForHenkilot(eqTo(personOids), any[RetryConfig]()))
       .thenReturn(Future.successful(emptyViitteet))
 
     val result = Await.result(onrIntegration.getAliasesForPersonOids(personOids), 5.seconds)
@@ -63,7 +65,7 @@ class OnrIntegrationTest {
       Henkiloviite(aliasForPersonOid1, personOid1),
     )
 
-    when(mockOnrClient.getHenkiloviitteetForHenkilot(personOids))
+    when(mockOnrClient.getHenkiloviitteetForHenkilot(eqTo(personOids), any[RetryConfig]()))
       .thenReturn(Future.successful(viitteet))
 
     val result = Await.result(onrIntegration.getAliasesForPersonOids(personOids), 5.seconds)
@@ -91,7 +93,7 @@ class OnrIntegrationTest {
       Henkiloviite(alias2ForPersonOid2, personOid2)
     )
 
-    when(mockOnrClient.getHenkiloviitteetForHenkilot(personOids))
+    when(mockOnrClient.getHenkiloviitteetForHenkilot(eqTo(personOids), any[RetryConfig]()))
       .thenReturn(Future.successful(viitteet))
 
     val result = Await.result(onrIntegration.getAliasesForPersonOids(personOids), 2.seconds)
@@ -120,7 +122,7 @@ class OnrIntegrationTest {
     )
 
     val personOids = Set(queriedOid)
-    when(mockOnrClient.getHenkiloviitteetForHenkilot(personOids))
+    when(mockOnrClient.getHenkiloviitteetForHenkilot(eqTo(personOids), any[RetryConfig]()))
       .thenReturn(Future.successful(viitteet))
 
     val result = Await.result(onrIntegration.getAliasesForPersonOids(personOids), 2.seconds)
@@ -137,7 +139,7 @@ class OnrIntegrationTest {
     val personOids = Set("1.2.3")
     val exception = new RuntimeException("Test error")
 
-    when(mockOnrClient.getHenkiloviitteetForHenkilot(personOids))
+    when(mockOnrClient.getHenkiloviitteetForHenkilot(eqTo(personOids), any[RetryConfig]()))
       .thenReturn(Future.failed(exception))
 
     val thrown = assertThrows(classOf[RuntimeException], () =>

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/UIResourceIntegraatioTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/UIResourceIntegraatioTest.scala
@@ -3,7 +3,7 @@ package fi.oph.suorituspalvelu
 import fi.oph.suorituspalvelu.business.LahtokouluTyyppi.VUOSILUOKKA_9
 import fi.oph.suorituspalvelu.business.SuoritusTila.VALMIS
 import fi.oph.suorituspalvelu.business.{AmmatillinenOpiskeluoikeus, AmmatillinenPerustutkinto, AvainArvoYliajo, EBArvosana, EBLaajuus, EBOppiaine, EBOppiaineenOsasuoritus, EBTutkinto, GeneerinenOpiskeluoikeus, HarkinnanvaraisuusYliajo, Koodi, Lahdejarjestelma, Lahtokoulu, Opiskeluoikeus, ParserVersions, PerusopetuksenOpiskeluoikeus, PerusopetuksenOppimaara, SuoritusTila}
-import fi.oph.suorituspalvelu.integration.client.{AtaruPermissionRequest, AtaruPermissionResponse, DateParam, HakemuspalveluClientImpl, KoutaHaku, KoutaHakukohde, Ohjausparametrit, OpintopolkuVastaanotto, Organisaatio, OrganisaatioNimi, VTSClient, VanhaTarjontaHaku, VanhaTarjontaHakukohde, Vastaanotot}
+import fi.oph.suorituspalvelu.integration.client.{AtaruPermissionRequest, AtaruPermissionResponse, DateParam, HakemuspalveluClientImpl, KoutaHaku, KoutaHakukohde, Ohjausparametrit, OpintopolkuVastaanotto, Organisaatio, OrganisaatioNimi, RetryConfig, VTSClient, VanhaTarjontaHaku, VanhaTarjontaHakukohde, Vastaanotot}
 import fi.oph.suorituspalvelu.integration.{HakukohderyhmaIntegration, OnrHenkiloPerustiedot, OnrIntegration, OnrMasterHenkilo, PersonOidsWithAliases, TarjontaIntegration}
 import fi.oph.suorituspalvelu.mankeli.{AvainArvoConstants, HarkinnanvaraisuudenSyy}
 import fi.oph.suorituspalvelu.parsing.koski.{Kielistetty, KoskiUtil}
@@ -16,6 +16,7 @@ import fi.oph.suorituspalvelu.service.UIService
 import fi.oph.suorituspalvelu.util.{HakuProvider, HakukohdeProvider, OrganisaatioProvider}
 import fi.oph.suorituspalvelu.validation.UIValidator
 import org.junit.jupiter.api.*
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
@@ -85,7 +86,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     ROOLI_ORGANISAATION_1_2_246_562_10_52320123196_KATSELIJA))
   @Test def testHaeKayttajanTiedotNotFound(): Unit =
     // mockataan onr-vastaus
-    Mockito.when(onrIntegration.getAsiointikieli("kayttaja")).thenReturn(Future.successful(None))
+    Mockito.when(onrIntegration.getAsiointikieli(eqTo("kayttaja"))(any[RetryConfig]())).thenReturn(Future.successful(None))
 
     // haetaan käyttäjän tiedot
     val result = mvc.perform(MockMvcRequestBuilders
@@ -100,7 +101,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
   @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_OPPIJOIDEN_KATSELIJA))
   @Test def testHaeKayttajanTiedotOppijoidenKatselijaAllowed(): Unit = {
     // mockataan onr-vastaus
-    Mockito.when(onrIntegration.getAsiointikieli("kayttaja")).thenReturn(Future.successful(Some("fi")))
+    Mockito.when(onrIntegration.getAsiointikieli(eqTo("kayttaja"))(any[RetryConfig]())).thenReturn(Future.successful(Some("fi")))
 
     // haetaan käyttäjän tiedot
     val result = mvc.perform(MockMvcRequestBuilders
@@ -116,7 +117,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
   @WithMockUser(value = "kayttaja", authorities = Array(SecurityConstants.SECURITY_ROOLI_HAKENEIDEN_KATSELIJA))
   @Test def testHaeKayttajanTiedotHakeneidenKatselijaAllowed(): Unit = {
     // mockataan onr-vastaus
-    Mockito.when(onrIntegration.getAsiointikieli("kayttaja")).thenReturn(Future.successful(Some("fi")))
+    Mockito.when(onrIntegration.getAsiointikieli(eqTo("kayttaja"))(any[RetryConfig]())).thenReturn(Future.successful(Some("fi")))
 
     // haetaan käyttäjän tiedot
     val result = mvc.perform(MockMvcRequestBuilders
@@ -632,7 +633,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
 
     // mockataan onr-vastaus
     val onrPerustiedot = OnrHenkiloPerustiedot(hakusanaOppijanumero, Some(etunimet), Some(sukunimi), Some(hetu))
-    Mockito.when(onrIntegration.getPerustiedotByPersonOids(Set(hakusanaOppijanumero)))
+    Mockito.when(onrIntegration.getPerustiedotByPersonOids(eqTo(Set(hakusanaOppijanumero)))(any[RetryConfig]()))
       .thenReturn(Future.successful(Seq(onrPerustiedot)))
 
     // mockataan organisaatiopalvelun vastaus
@@ -731,7 +732,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val oppijaNumero = "1.2.246.562.24.21250967216"
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map.empty))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map.empty))
 
     // suoritetaan kutsu ja parseroidaan vastaus
     val request = OppijanTiedotRequest(Optional.of(oppijaNumero), Optional.empty())
@@ -763,8 +764,8 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     kantaOperaatiot.tallennaVersioonLiittyvatEntiteetit(koskiVersio.get, opiskeluoikeudet, KoskiUtil.getLahtokouluMetadata(opiskeluoikeudet), ParserVersions.KOSKI)
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, syntymaAika))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, syntymaAika))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     // suoritetaan kutsu ja parseroidaan vastaus
     val request = OppijanTiedotRequest(Optional.of(oppijaNumero), Optional.empty())
@@ -795,8 +796,8 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val organisaatio = Organisaatio(oppilaitosOid, OrganisaatioNimi("org nimi", "org namn", "org name"), None, Seq.empty, Seq.empty)
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, syntymaAika))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, syntymaAika))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     // mockataan Hakemuspalvelun vastaus, kun kysytään hakukohderyhmäoidilla
     Mockito.when(hakemuspalveluClient.checkPermission(AtaruPermissionRequest(Set(oppijaNumero), Set(oppilaitosOid), Set.empty)))
@@ -829,8 +830,8 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val syntymaAika = Some(LocalDate.of(2000, 1, 1))
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, syntymaAika))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, syntymaAika))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     // mockataan Hakemuspalvelun vastaus, kun kysytään hakukohderyhmäoidilla
     Mockito.when(hakemuspalveluClient.checkPermission(AtaruPermissionRequest(Set(oppijaNumero), Set("1.2.246.562.28.36220136912"), Set.empty)))
@@ -869,9 +870,9 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     ), List.empty, ParserVersions.KOSKI)
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, Some(henkilotunnus), None, None))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
-    Mockito.when(onrIntegration.getPerustiedotByHetus(Set(henkilotunnus))).thenReturn(Future.successful(List(OnrHenkiloPerustiedot(oppijaNumero, None, None, Some(henkilotunnus)))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, Some(henkilotunnus), None, None))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getPerustiedotByHetus(eqTo(Set(henkilotunnus)))(any[RetryConfig]())).thenReturn(Future.successful(List(OnrHenkiloPerustiedot(oppijaNumero, None, None, Some(henkilotunnus)))))
 
     // suoritetaan kutsu ja parseroidaan vastaus
     val request = OppijanTiedotRequest(Optional.of(henkilotunnus), Optional.empty())
@@ -898,7 +899,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val henkilotunnus = "123456-789A"
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.getPerustiedotByHetus(Set(henkilotunnus))).thenReturn(Future.successful(List.empty))
+    Mockito.when(onrIntegration.getPerustiedotByHetus(eqTo(Set(henkilotunnus)))(any[RetryConfig]())).thenReturn(Future.successful(List.empty))
 
     // suoritetaan kutsu ja parseroidaan vastaus
     val request = OppijanTiedotRequest(Optional.of(henkilotunnus), Optional.empty())
@@ -914,7 +915,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val henkilotunnus = "123456-789A"
 
     // mockataan ONR-vastaus palauttamaan virheen
-    Mockito.when(onrIntegration.getPerustiedotByHetus(Set(henkilotunnus))).thenReturn(Future.failed(new RuntimeException("ONR connection failed")))
+    Mockito.when(onrIntegration.getPerustiedotByHetus(eqTo(Set(henkilotunnus)))(any[RetryConfig]())).thenReturn(Future.failed(new RuntimeException("ONR connection failed")))
 
     // suoritetaan kutsu ja tarkistetaan että palautetaan 500
     val request = OppijanTiedotRequest(Optional.of(henkilotunnus), Optional.empty())
@@ -933,7 +934,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val organisaatio = Organisaatio(UIService.EXAMPLE_OPPILAITOS_OID, OrganisaatioNimi("org nimi", "org namn", "org name"), None, Seq.empty, Seq.empty)
 
     // mockataan ONR-vastaus suorituksen tallennusta varten
-    Mockito.when(onrIntegration.henkiloExists(oppijaNumero)).thenReturn(Future.successful(true))
+    Mockito.when(onrIntegration.henkiloExists(eqTo(oppijaNumero))(any[RetryConfig]())).thenReturn(Future.successful(true))
     Mockito.when(organisaatioProvider.haeOrganisaationTiedot(UIService.EXAMPLE_OPPILAITOS_OID)).thenReturn(Some(organisaatio))
 
     // tallennetaan käsin syötetty oppimäärä
@@ -946,8 +947,8 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
       .andReturn()
 
     // mockataan ONR-vastaus tietojen hakua varten
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     // suoritetaan kutsu ja parseroidaan vastaus
     val request = OppijanTiedotRequest(Optional.of(oppijaNumero), Optional.empty())
@@ -1177,7 +1178,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val oppijaNumero = "1.2.246.562.24.21250967216"
 
     // mockataan ONR-vastaus - henkilöä ei löydy
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map.empty))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map.empty))
 
     // suoritetaan kutsu
     val request = OppijanVastaanototRequest(Optional.of(oppijaNumero))
@@ -1192,8 +1193,8 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val oppijaNumero = "1.2.246.562.24.21250967230"
 
     // mockataan ONR-vastaukset
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     // mockataan VTS-vastaus - ei vastaanottoja
     Mockito.when(vtsClient.fetchVastaanotot(oppijaNumero)).thenReturn(Future.successful(None))
@@ -1229,8 +1230,8 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val vanhaTarjoajaOid2 = "1.2.246.562.10.00000000003"
 
     // mockataan ONR-vastaukset
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     // mockataan VTS-vastaus: yksi Kouta-vastaanotto ja yksi vanhan tarjonnan vastaanotto
     val koutaVastaanotto = OpintopolkuVastaanotto(oppijaNumero, hakuOid, hakukohdeOid, "VastaanotaSitovasti", "2025-07-15T10:00:00Z")
@@ -1321,8 +1322,8 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val oppijaNumero = "1.2.246.562.24.21250967232"
 
     // mockataan ONR-vastaukset
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     // mockataan VTS-vastaus palauttamaan virheen
     Mockito.when(vtsClient.fetchVastaanotot(oppijaNumero)).thenReturn(Future.failed(new RuntimeException("VTS connection failed")))
@@ -1439,7 +1440,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val oppijaNumero = "1.2.246.562.24.21250967214"
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.henkiloExists(oppijaNumero)).thenReturn(Future.successful(false))
+    Mockito.when(onrIntegration.henkiloExists(eqTo(oppijaNumero))(any[RetryConfig]())).thenReturn(Future.successful(false))
 
     // tuntematon henkilöoid ei sallittu
     val result = mvc.perform(MockMvcRequestBuilders
@@ -1459,7 +1460,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val organisaatio = Organisaatio(UIService.EXAMPLE_OPPILAITOS_OID, OrganisaatioNimi("org nimi", "org namn", "org name"), None, Seq.empty, Seq.empty)
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.henkiloExists(oppijaNumero)).thenReturn(Future.successful(true))
+    Mockito.when(onrIntegration.henkiloExists(eqTo(oppijaNumero))(any[RetryConfig]())).thenReturn(Future.successful(true))
     Mockito.when(organisaatioProvider.haeOrganisaationTiedot(UIService.EXAMPLE_OPPILAITOS_OID)).thenReturn(Some(organisaatio))
 
     // validin suorituksen tallentaminen tunnetulle henkilölle ok
@@ -1554,7 +1555,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val oppijaNumero = "1.2.246.562.24.21250967211"
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.henkiloExists(oppijaNumero)).thenReturn(Future.successful(false))
+    Mockito.when(onrIntegration.henkiloExists(eqTo(oppijaNumero))(any[RetryConfig]())).thenReturn(Future.successful(false))
 
     // tuntematon henkilöoid ei sallittu
     val result = mvc.perform(MockMvcRequestBuilders
@@ -1574,7 +1575,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val organisaatio = Organisaatio(UIService.EXAMPLE_OPPILAITOS_OID, OrganisaatioNimi("org nimi", "org namn", "org name"), None, Seq.empty, Seq.empty)
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.henkiloExists(oppijaNumero)).thenReturn(Future.successful(true))
+    Mockito.when(onrIntegration.henkiloExists(eqTo(oppijaNumero))(any[RetryConfig]())).thenReturn(Future.successful(true))
     Mockito.when(organisaatioProvider.haeOrganisaationTiedot(UIService.EXAMPLE_OPPILAITOS_OID)).thenReturn(Some(organisaatio))
 
     // validin suorituksen tallentaminen tunnetulle henkilölle ok
@@ -1607,7 +1608,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     val oppijaNumero = "1.2.246.562.24.21250967214"
     val organisaatio = Organisaatio(UIService.EXAMPLE_OPPILAITOS_OID, OrganisaatioNimi("org nimi", "org namn", "org name"), None, Seq.empty, Seq.empty)
 
-    Mockito.when(onrIntegration.henkiloExists(oppijaNumero)).thenReturn(Future.successful(true))
+    Mockito.when(onrIntegration.henkiloExists(eqTo(oppijaNumero))(any[RetryConfig]())).thenReturn(Future.successful(true))
     Mockito.when(organisaatioProvider.haeOrganisaationTiedot(UIService.EXAMPLE_OPPILAITOS_OID)).thenReturn(Some(organisaatio))
 
     // tallennetaan ensin perusopetuksen oppimäärä
@@ -1796,7 +1797,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     kantaOperaatiot.tallennaYliajot(Seq(yliajo, eriHaunYliajo))
     val versio = kantaOperaatiot.tallennaJarjestelmaVersio(oppijaNumero, Lahdejarjestelma.SYOTETYT_OPPIAINEET, Seq.empty, Seq.empty, Instant.now(), "SYOTETTY", None)
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
 
     Mockito.when(tarjontaIntegration.getHaku(hakuOid))
@@ -1970,7 +1971,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     )
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.henkiloExists(oppijaNumero)).thenReturn(Future.successful(true))
+    Mockito.when(onrIntegration.henkiloExists(eqTo(oppijaNumero))(any[RetryConfig]())).thenReturn(Future.successful(true))
 
     // validin suorituksen tallentaminen tunnetulle henkilölle ok
     val yliajotPayload = objectMapper.writeValueAsString(yliajoContainer)
@@ -2055,7 +2056,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     )
 
     // mockataan ONR-vastaus
-    Mockito.when(onrIntegration.henkiloExists(oppijaNumero)).thenReturn(Future.successful(true))
+    Mockito.when(onrIntegration.henkiloExists(eqTo(oppijaNumero))(any[RetryConfig]())).thenReturn(Future.successful(true))
 
     val yliajotPayload = objectMapper.writeValueAsString(yliajoContainer)
     val result = mvc.perform(MockMvcRequestBuilders
@@ -2215,9 +2216,9 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
     ), Seq.empty, ParserVersions.KOSKI)
 
     // Mock ONR & organisaatiopalvelu
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero)))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]()))
       .thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set(oppijaNumero)))))
     val organisaatio = Organisaatio(oppilaitosOid, OrganisaatioNimi(oppilaitosNimi, "Europaskolan i Helsingfors", "European School of Helsinki"), None, Seq.empty, Seq.empty)
     Mockito.when(organisaatioProvider.haeOrganisaationTiedot(oppilaitosOid)).thenReturn(Some(organisaatio))
@@ -2338,7 +2339,7 @@ class UIResourceIntegraatioTest extends BaseIntegraatioTesti {
       ApiConstants.ESIMERKKI_OPPIJANUMERO, ApiConstants.ESIMERKKI_HAKU_OID, ApiConstants.ESIMERKKI_YLIAJO_VIRKAILIJA, selite)), tallennusHetki)
 
     // mockataan onr-vastaus ja tehdään kutsu
-    Mockito.when(onrIntegration.getPerustiedotByPersonOids(Set(ApiConstants.ESIMERKKI_YLIAJO_VIRKAILIJA)))
+    Mockito.when(onrIntegration.getPerustiedotByPersonOids(eqTo(Set(ApiConstants.ESIMERKKI_YLIAJO_VIRKAILIJA)))(any[RetryConfig]()))
       .thenReturn(Future.successful(Seq(OnrHenkiloPerustiedot(ApiConstants.ESIMERKKI_YLIAJO_VIRKAILIJA, Some(virkailijaEtunimi), Some(virkailijaSukunimi), None))))
     val result = mvc.perform(MockMvcRequestBuilders
         .get(ApiConstants.UI_YLIAJOT_HISTORIA_PATH, "")

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/ValintalaskentaResourceIntegraatioTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/ValintalaskentaResourceIntegraatioTest.scala
@@ -244,7 +244,7 @@ class ValintalaskentaResourceIntegraatioTest extends BaseIntegraatioTesti {
       .thenReturn(Ohjausparametrit(suoritustenVahvistuspaiva = Some(DateParam(1765290747152L)), valintalaskentapaiva = Some(DateParam(1768290647351L))))
     Mockito.when(hakemuspalveluClient.getValintalaskentaHakemukset(Some(hakukohdeOid), false, Set.empty, false))
       .thenReturn(Future.successful(Seq(testHakemus)))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(personOid)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(personOid)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(personOid -> Set(personOid)))))
     Mockito.when(hakukohderyhmaIntegration.getHakukohderyhmatForHaku(hakuOid))
       .thenReturn(Map(

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/ValintalaskentaResourceIntegraatioTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/ValintalaskentaResourceIntegraatioTest.scala
@@ -1,6 +1,6 @@
 package fi.oph.suorituspalvelu
 
-import fi.oph.suorituspalvelu.integration.client.{AtaruValintalaskentaHakemus, DateParam, HakemuspalveluClientImpl, Hakutoive, KoutaHaku, Ohjausparametrit}
+import fi.oph.suorituspalvelu.integration.client.{AtaruValintalaskentaHakemus, DateParam, HakemuspalveluClientImpl, Hakutoive, KoutaHaku, Ohjausparametrit, RetryConfig}
 import fi.oph.suorituspalvelu.integration.{HakukohderyhmaIntegration, OnrIntegration, PersonOidsWithAliases, TarjontaIntegration}
 import fi.oph.suorituspalvelu.resource.ApiConstants
 import fi.oph.suorituspalvelu.resource.api.{ValintalaskentaDataFailureResponse, ValintalaskentaDataPayload, ValintalaskentaDataSuccessResponse}
@@ -8,6 +8,7 @@ import fi.oph.suorituspalvelu.security.{AuditOperation, SecurityConstants}
 import fi.oph.suorituspalvelu.util.OrganisaatioProvider
 import org.junit.jupiter.api.*
 import org.mockito.Mockito
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.springframework.test.context.bean.`override`.mockito.MockitoBean
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.{WithAnonymousUser, WithMockUser}
@@ -136,7 +137,7 @@ class ValintalaskentaResourceIntegraatioTest extends BaseIntegraatioTesti {
 
     Mockito.when(hakemuspalveluClient.getValintalaskentaHakemukset(Some(hakukohdeOid), false, Set.empty, false))
       .thenReturn(Future.successful(Seq(testHakemus)))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(personOid)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(personOid)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(personOid -> Set(personOid)))))
     Mockito.when(hakukohderyhmaIntegration.getHakukohderyhmatForHaku(hakuOid))
       .thenReturn(Map.empty)

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/VirtaResourceIntegraatioTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/VirtaResourceIntegraatioTest.scala
@@ -2,7 +2,7 @@ package fi.oph.suorituspalvelu
 
 import fi.oph.suorituspalvelu.business.{KKOpiskeluoikeus, KKSynteettinenSuoritus, KKTutkinto, Opiskeluoikeus, VersioEntiteetti}
 import fi.oph.suorituspalvelu.integration.{OnrIntegration, OnrMasterHenkilo, PersonOidsWithAliases}
-import fi.oph.suorituspalvelu.integration.client.{AtaruHakemuksenHenkilotiedot, HakemuspalveluClientImpl}
+import fi.oph.suorituspalvelu.integration.client.{AtaruHakemuksenHenkilotiedot, HakemuspalveluClientImpl, RetryConfig}
 import fi.oph.suorituspalvelu.integration.virta.VirtaClient
 import fi.oph.suorituspalvelu.parsing.OpiskeluoikeusParsingService
 import fi.oph.suorituspalvelu.resource.ApiConstants
@@ -11,6 +11,7 @@ import fi.oph.suorituspalvelu.security.{AuditOperation, SecurityConstants}
 import fi.oph.suorituspalvelu.service.VirtaUtil
 import fi.oph.suorituspalvelu.validation.Validator
 import org.junit.jupiter.api.*
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.test.context.support.{WithAnonymousUser, WithMockUser}
@@ -102,8 +103,8 @@ class VirtaResourceIntegraatioTest extends BaseIntegraatioTesti {
     val oppijaNumero = "1.2.246.562.24.21250967215"
 
     // mockataan ONR- ja VIRTA-vastaukset
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set.empty))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set.empty))))
     Mockito.when(virtaClient.haeTiedotOppijanumerolle(oppijaNumero)).thenReturn(Future.successful(scala.io.Source.fromResource("1_2_246_562_24_21250967215.xml").mkString))
 
     // suoritetaan kutsu ja varmistetaan että saadaan jobId
@@ -129,8 +130,8 @@ class VirtaResourceIntegraatioTest extends BaseIntegraatioTesti {
 
     val virtaXml: String = scala.io.Source.fromResource("1_2_246_562_24_21250967215.xml").mkString
 
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaNumero))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set.empty))))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(Map(oppijaNumero -> OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaNumero)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaNumero -> Set.empty))))
     Mockito.when(virtaClient.haeTiedotOppijanumerolle(oppijaNumero)).thenReturn(Future.successful(virtaXml))
 
     val result = mvc.perform(jsonPost(ApiConstants.VIRTA_DATASYNC_HENKILO_PATH, VirtaPaivitaTiedotHenkilollePayload(Optional.of(oppijaNumero))))
@@ -188,9 +189,9 @@ class VirtaResourceIntegraatioTest extends BaseIntegraatioTesti {
 
     val virtaXml: String = scala.io.Source.fromResource("1_2_246_562_24_21250967215.xml").mkString
 
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(haunHakijatOids.toSet))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(haunHakijatOids.toSet))(any[RetryConfig]()))
       .thenReturn(Future.successful(haunHakijatOids.map(oppijaNumero => (oppijaNumero, OnrMasterHenkilo(oppijaNumero, None, None, None, None, None))).toMap))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(haunHakijatOids.toSet))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(haunHakijatOids.toSet))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(aliasMap)))
     Mockito.when(hakemuspalveluClient.getHaunHakijat(hakuOid))
       .thenReturn(Future.successful(henkiloTiedot))

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/YtrSyncIntegraatioTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/YtrSyncIntegraatioTest.scala
@@ -4,7 +4,7 @@ package fi.oph.suorituspalvelu
 
 import com.nimbusds.jose.util.StandardCharset
 import fi.oph.suorituspalvelu.business.Lahdejarjestelma
-import fi.oph.suorituspalvelu.integration.client.{AtaruHakemuksenHenkilotiedot, HakemuspalveluClientImpl, KoutaHaku, YtrClient, YtrHetuPostData, YtrMassOperation, YtrMassOperationQueryResponse}
+import fi.oph.suorituspalvelu.integration.client.{AtaruHakemuksenHenkilotiedot, HakemuspalveluClientImpl, KoutaHaku, YtrClient, YtrHetuPostData, YtrMassOperation, YtrMassOperationQueryResponse, RetryConfig}
 import fi.oph.suorituspalvelu.integration.ytr.YtrDataForHenkilo
 import fi.oph.suorituspalvelu.parsing.OpiskeluoikeusParsingService
 import fi.oph.suorituspalvelu.parsing.ytr.YtrParser
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.{Assertions, Test, TestInstance}
 import org.springframework.security.test.context.support.{WithAnonymousUser, WithMockUser}
 import org.mockito.Mockito
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import fi.oph.suorituspalvelu.integration.{OnrIntegration, OnrMasterHenkilo, TarjontaIntegration}
 import fi.oph.suorituspalvelu.security.SecurityConstants
 import fi.oph.suorituspalvelu.resource.ApiConstants
@@ -147,7 +148,7 @@ class YtrSyncIntegraatioTest extends BaseIntegraatioTesti {
       personOid -> OnrMasterHenkilo(personOid, None, None, hetuToPersonOid.find(_._2 == personOid).map(_._1), None, None)
     }).toMap
 
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(hetuToPersonOid.values.toSet))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(hetuToPersonOid.values.toSet))(any[RetryConfig]()))
       .thenReturn(Future.successful(onrData))
     Mockito.when(ytrClient.fetchOne(YtrHetuPostData(hetuToPersonOid.keySet.head, Some(List.empty))))
       .thenReturn(Future.successful(Some(personJson)))
@@ -217,7 +218,7 @@ class YtrSyncIntegraatioTest extends BaseIntegraatioTesti {
 
     Mockito.when(hakemuspalveluClient.getHaunHakijat(hakuOid))
       .thenReturn(Future.successful(ataruTiedot))
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(hetuToPersonOid.values.toSet))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(hetuToPersonOid.values.toSet))(any[RetryConfig]()))
       .thenReturn(Future.successful(onrData))
     Mockito.when(ytrClient.createYtrMassOperation(org.mockito.ArgumentMatchers.any()))
       .thenReturn(Future.successful(massOperation))
@@ -277,7 +278,7 @@ class YtrSyncIntegraatioTest extends BaseIntegraatioTesti {
 
     Mockito.when(hakemuspalveluClient.getHaunHakijat(hakuOid))
       .thenReturn(Future.successful(ataruTiedot))
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(hetuToPersonOid.values.toSet))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(hetuToPersonOid.values.toSet))(any[RetryConfig]()))
       .thenReturn(Future.successful(onrData))
     Mockito.when(ytrClient.createYtrMassOperation(org.mockito.ArgumentMatchers.any()))
       .thenReturn(Future.successful(massOperation))
@@ -336,7 +337,7 @@ class YtrSyncIntegraatioTest extends BaseIntegraatioTesti {
 
     Mockito.when(hakemuspalveluClient.getHaunHakijat(hakuOid))
       .thenReturn(Future.successful(ataruTiedot))
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(hetuToPersonOid.values.toSet))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(hetuToPersonOid.values.toSet))(any[RetryConfig]()))
       .thenReturn(Future.successful(onrData))
     Mockito.when(ytrClient.createYtrMassOperation(org.mockito.ArgumentMatchers.any()))
       .thenReturn(Future.failed(new RuntimeException("Temporary create failure")))
@@ -395,7 +396,7 @@ class YtrSyncIntegraatioTest extends BaseIntegraatioTesti {
 
     Mockito.when(hakemuspalveluClient.getHaunHakijat(hakuOid))
       .thenReturn(Future.successful(ataruTiedot))
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(hetuToPersonOid.values.toSet))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(hetuToPersonOid.values.toSet))(any[RetryConfig]()))
       .thenReturn(Future.successful(onrData))
     Mockito.when(ytrClient.createYtrMassOperation(org.mockito.ArgumentMatchers.any()))
       .thenReturn(Future.successful(massOperation))
@@ -465,7 +466,7 @@ class YtrSyncIntegraatioTest extends BaseIntegraatioTesti {
 
     Mockito.when(hakemuspalveluClient.getHaunHakijat(hakuOid))
       .thenReturn(Future.successful(ataruTiedot))
-    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(personOids.toSet))
+    Mockito.when(onrIntegration.getMasterHenkilosForPersonOids(eqTo(personOids.toSet))(any[RetryConfig]()))
       .thenReturn(Future.successful(onrData))
     Mockito.when(ytrClient.createYtrMassOperation(org.mockito.ArgumentMatchers.any()))
       .thenReturn(Future.successful(massOperation))

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/service/LahtokoulutServiceTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/service/LahtokoulutServiceTest.scala
@@ -9,6 +9,7 @@ import fi.oph.suorituspalvelu.integration.client.*
 import fi.oph.suorituspalvelu.parsing.koski.{Kielistetty, KoskiUtil}
 import fi.oph.suorituspalvelu.util.OrganisaatioProvider
 import org.junit.jupiter.api.{Assertions, Test}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.`override`.mockito.MockitoBean
@@ -120,7 +121,7 @@ class LahtokoulutServiceTest extends BaseIntegraatioTesti {
   @Test def testHaeOhjattavatJaLuokatTamaVuosi(): Unit =
     lisaaSuoritukset()
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(OPPIJANUMERO_YSI_KESKEN, OPPIJANUMERO_YSI_VALMIS_TAMA_VUOSI)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(OPPIJANUMERO_YSI_KESKEN, OPPIJANUMERO_YSI_VALMIS_TAMA_VUOSI)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(OPPIJANUMERO_YSI_KESKEN -> Set(OPPIJANUMERO_YSI_KESKEN), OPPIJANUMERO_YSI_VALMIS_TAMA_VUOSI -> Set(OPPIJANUMERO_YSI_VALMIS_TAMA_VUOSI)))))
 
     // palautuu oppijat joilla keskeneräinen tai valmis suoritus tältä vuodelta
@@ -132,7 +133,7 @@ class LahtokoulutServiceTest extends BaseIntegraatioTesti {
   @Test def testHaeOhjattavatJaLuokatViimevuosi(): Unit =
     lisaaSuoritukset()
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI -> Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI)))))
 
     // palautuu vain oppijat joilla valmis suoritus haetulta vuodelta
@@ -152,7 +153,7 @@ class LahtokoulutServiceTest extends BaseIntegraatioTesti {
   @Test def testHaeOhjattavatJaLuokatTamaVuosiLuokka(): Unit =
     lisaaSuoritukset()
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(OPPIJANUMERO_YSI_KESKEN, OPPIJANUMERO_YSI_VALMIS_TAMA_VUOSI)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(OPPIJANUMERO_YSI_KESKEN, OPPIJANUMERO_YSI_VALMIS_TAMA_VUOSI)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(OPPIJANUMERO_YSI_KESKEN -> Set(OPPIJANUMERO_YSI_KESKEN), OPPIJANUMERO_YSI_VALMIS_TAMA_VUOSI -> Set(OPPIJANUMERO_YSI_VALMIS_TAMA_VUOSI)))))
 
     // palautuu oppijat joilla keskeneräinen tai valmis suoritus tältä vuodelta ja luokka täsmää
@@ -164,7 +165,7 @@ class LahtokoulutServiceTest extends BaseIntegraatioTesti {
   @Test def testHaeOhjattavatJaLuokatViimevuosiLuokka(): Unit =
     lisaaSuoritukset()
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI -> Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI)))))
 
     // palautuu oppijat joilla valmis suoritus haetulta vuodelta ja luokka täsmää
@@ -176,7 +177,7 @@ class LahtokoulutServiceTest extends BaseIntegraatioTesti {
   @Test def testHaeOhjattavatJaLuokatAlias(): Unit =
     lisaaSuoritukset()
 
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI)))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI)))(any[RetryConfig]()))
       .thenReturn(Future.successful(PersonOidsWithAliases(Map(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI -> Set(OPPIJANUMERO_YSI_VALMIS_VIIMEVUOSI, OPPIJANUMERO_ALIAS)))))
 
     // palautuu oppijat joilla valmis suoritus haetulta vuodelta ja luokka täsmää

--- a/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/service/UIServiceTest.scala
+++ b/suorituspalvelu-service/src/test/scala/fi/oph/suorituspalvelu/service/UIServiceTest.scala
@@ -3,13 +3,14 @@ package fi.oph.suorituspalvelu.service
 import fi.oph.suorituspalvelu.BaseIntegraatioTesti
 import fi.oph.suorituspalvelu.business.LahtokouluTyyppi.VUOSILUOKKA_9
 import fi.oph.suorituspalvelu.business.SuoritusTila.VALMIS
-import fi.oph.suorituspalvelu.business.{Koodi, Lahtokoulu, Opiskeluoikeus, ParserVersions, PerusopetuksenOpiskeluoikeus, PerusopetuksenOppimaara, Lahdejarjestelma}
+import fi.oph.suorituspalvelu.business.{Koodi, Lahdejarjestelma, Lahtokoulu, Opiskeluoikeus, ParserVersions, PerusopetuksenOpiskeluoikeus, PerusopetuksenOppimaara}
 import fi.oph.suorituspalvelu.integration.client.*
 import fi.oph.suorituspalvelu.integration.{OnrIntegration, PersonOidsWithAliases}
 import fi.oph.suorituspalvelu.parsing.koski.{Kielistetty, KoskiUtil}
 import fi.oph.suorituspalvelu.security.SecurityConstants
 import fi.oph.suorituspalvelu.util.OrganisaatioProvider
 import org.junit.jupiter.api.{Assertions, Test}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.test.context.support.WithMockUser
@@ -46,7 +47,7 @@ class UIServiceTest extends BaseIntegraatioTesti {
     val oppijaOid = "1.2.246.562.24.21583363334"
 
     // mockataan onr-vastaus, ei aliaksia
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaOid))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaOid -> Set(oppijaOid)))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaOid)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaOid -> Set(oppijaOid)))))
 
     Assertions.assertEquals(false, uiService.hasOppijanKatseluOikeus(oppijaOid))
 
@@ -61,7 +62,7 @@ class UIServiceTest extends BaseIntegraatioTesti {
     val permissionRequest = AtaruPermissionRequest(Set(oppijaOid), Set(oppilaitosOid), Set.empty)
     val permissionResponse = AtaruPermissionResponse(Some(onOikeus), None)
     Mockito.when(organisaatioProvider.haeOrganisaationTiedot(oppilaitosOid)).thenReturn(Some(organisaatio))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaOid))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaOid -> Set(oppijaOid)))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaOid)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaOid -> Set(oppijaOid)))))
     Mockito.when(hakemuspalveluClient.checkPermission(permissionRequest)).thenReturn(Future.successful(permissionResponse))
 
     // palautuu atarun vastaus
@@ -76,7 +77,7 @@ class UIServiceTest extends BaseIntegraatioTesti {
 
     // mockataan onr ja organisaatiopalvelun vastaukset
     Mockito.when(organisaatioProvider.haeOrganisaationTiedot(oppilaitosOid)).thenReturn(Some(organisaatio))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaOid))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaOid -> Set(oppijaOid)))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaOid)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaOid -> Set(oppijaOid)))))
 
     // tallennetaan valmis perusopetuksen oppimäärä
     val versio = kantaOperaatiot.tallennaJarjestelmaVersio(oppijaOid, Lahdejarjestelma.KOSKI, Seq.empty, Seq.empty, Instant.now(), "1.2.3", Some(1))
@@ -121,7 +122,7 @@ class UIServiceTest extends BaseIntegraatioTesti {
 
     // mockataan onr ja organisaatiopalvelun vastaukset
     Mockito.when(organisaatioProvider.haeOrganisaationTiedot(oppilaitosJohonOikeudetOid)).thenReturn(Some(organisaatio))
-    Mockito.when(onrIntegration.getAliasesForPersonOids(Set(oppijaOid))).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaOid -> Set(oppijaOid)))))
+    Mockito.when(onrIntegration.getAliasesForPersonOids(eqTo(Set(oppijaOid)))(any[RetryConfig]())).thenReturn(Future.successful(PersonOidsWithAliases(Map(oppijaOid -> Set(oppijaOid)))))
 
     // tallennetaan valmis perusopetuksen oppimäärä
     val versio = kantaOperaatiot.tallennaJarjestelmaVersio(oppijaOid, Lahdejarjestelma.KOSKI, Seq.empty, Seq.empty, Instant.now(), "1.2.3", Some(1))

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/OnrIntegration.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/OnrIntegration.scala
@@ -1,6 +1,6 @@
 package fi.oph.suorituspalvelu.integration
 
-import fi.oph.suorituspalvelu.integration.client.{Henkiloviite, OnrClientImpl}
+import fi.oph.suorituspalvelu.integration.client.{Henkiloviite, OnrClientImpl, RetryConfig}
 import org.springframework.beans.factory.annotation.Autowired
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -46,17 +46,17 @@ trait OnrIntegration {
    * @param personOids  joukko master- tai duplikaattihenkilöoideja joilla halutaan aliakset
    * @return            duplikaatit per haettu henkilöOid
    */
-  def getAliasesForPersonOids(personOids: Set[String]): Future[PersonOidsWithAliases]
+  def getAliasesForPersonOids(personOids: Set[String])(implicit retryConfig: RetryConfig): Future[PersonOidsWithAliases]
 
-  def getMasterHenkilosForPersonOids(personOids: Set[String]): Future[Map[String, OnrMasterHenkilo]]
+  def getMasterHenkilosForPersonOids(personOids: Set[String])(implicit retryConfig: RetryConfig): Future[Map[String, OnrMasterHenkilo]]
 
-  def getAsiointikieli(oid: String): Future[Option[String]]
+  def getAsiointikieli(oid: String)(implicit retryConfig: RetryConfig): Future[Option[String]]
 
-  def henkiloExists(oid: String): Future[Boolean]
+  def henkiloExists(oid: String)(implicit retryConfig: RetryConfig): Future[Boolean]
 
-  def getPerustiedotByHetus(hetus: Set[String]): Future[Seq[OnrHenkiloPerustiedot]]
+  def getPerustiedotByHetus(hetus: Set[String])(implicit retryConfig: RetryConfig): Future[Seq[OnrHenkiloPerustiedot]]
 
-  def getPerustiedotByPersonOids(personOids: Set[String]): Future[Seq[OnrHenkiloPerustiedot]]
+  def getPerustiedotByPersonOids(personOids: Set[String])(implicit retryConfig: RetryConfig): Future[Seq[OnrHenkiloPerustiedot]]
 }
 
 class OnrIntegrationImpl extends OnrIntegration {
@@ -67,8 +67,8 @@ class OnrIntegrationImpl extends OnrIntegration {
 
   @Autowired val onrClient: OnrClientImpl = null
 
-  override def getAliasesForPersonOids(personOids: Set[String]): Future[PersonOidsWithAliases] = {
-    val viitteet: Future[Set[Henkiloviite]] = onrClient.getHenkiloviitteetForHenkilot(personOids)
+  override def getAliasesForPersonOids(personOids: Set[String])(implicit retryConfig: RetryConfig): Future[PersonOidsWithAliases] = {
+    val viitteet: Future[Set[Henkiloviite]] = onrClient.getHenkiloviitteetForHenkilot(personOids, retryConfig)
 
     viitteet.flatMap((viiteResult: Set[Henkiloviite]) => {
       LOG.info(s"Got ${viiteResult.size} viittees for ${personOids.size} personOids")
@@ -91,24 +91,24 @@ class OnrIntegrationImpl extends OnrIntegration {
     })
   }
 
-  override def getMasterHenkilosForPersonOids(personOids: Set[String]): Future[Map[String, OnrMasterHenkilo]] = {
-    onrClient.getMasterHenkilosForPersonOids(personOids)
+  override def getMasterHenkilosForPersonOids(personOids: Set[String])(implicit retryConfig: RetryConfig): Future[Map[String, OnrMasterHenkilo]] = {
+    onrClient.getMasterHenkilosForPersonOids(personOids, retryConfig)
   }
 
-  override def getAsiointikieli(oid: String): Future[Option[String]] =
-    onrClient.getAsiointikieli(oid)
+  override def getAsiointikieli(oid: String)(implicit retryConfig: RetryConfig): Future[Option[String]] =
+    onrClient.getAsiointikieli(oid, retryConfig)
 
-  override def henkiloExists(oid: String): Future[Boolean] =
-    this.getAsiointikieli(oid).map(optKieli => optKieli.isDefined)
+  override def henkiloExists(oid: String)(implicit retryConfig: RetryConfig): Future[Boolean] =
+    this.getAsiointikieli(oid)(retryConfig).map(optKieli => optKieli.isDefined)
 
-  override def getPerustiedotByHetus(hetus: Set[String]): Future[Seq[OnrHenkiloPerustiedot]] = {
-    onrClient.getPerustiedotByHetus(hetus)
+  override def getPerustiedotByHetus(hetus: Set[String])(implicit retryConfig: RetryConfig): Future[Seq[OnrHenkiloPerustiedot]] = {
+    onrClient.getPerustiedotByHetus(hetus, retryConfig)
   }
 
-  override def getPerustiedotByPersonOids(personOids: Set[String]): Future[Seq[OnrHenkiloPerustiedot]] = {
+  override def getPerustiedotByPersonOids(personOids: Set[String])(implicit retryConfig: RetryConfig): Future[Seq[OnrHenkiloPerustiedot]] = {
     if(personOids.isEmpty)
       Future.successful(Seq.empty)
     else
-      onrClient.getPerustiedotByPersonOids(personOids)
+      onrClient.getPerustiedotByPersonOids(personOids, retryConfig)
   }
 }

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/Util.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/Util.scala
@@ -6,6 +6,8 @@ import scala.annotation.tailrec
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent.{Await, Future, Promise}
 
+class NonRetriableException(message: String) extends RuntimeException(message)
+
 object Util {
 
   private val LOG: Logger = LoggerFactory.getLogger(Util.getClass)
@@ -52,6 +54,9 @@ object Util {
           try
             Await.result(operation, Duration.Inf)
           catch
+            case e: NonRetriableException =>
+              LOG.error(s"$failMessage: ${e.getMessage}. Virhe ei ole uudelleenyritettävissä.")
+              throw e
             case e: Throwable if remainingRetries > 0 =>
               LOG.warn(
                 s"$failMessage: ${e.getMessage}. Yritetään uudelleen ${currentDelay}ms kuluttua ($remainingRetries yritystä jäljellä)."

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/client/OnrClient.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/client/OnrClient.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import fi.oph.suorituspalvelu.integration.{OnrHenkiloPerustiedot, OnrMasterHenkilo}
+import fi.oph.suorituspalvelu.integration.{NonRetriableException, OnrHenkiloPerustiedot, OnrMasterHenkilo, Util}
 import fi.vm.sade.javautils.nio.cas.CasClient
 import org.asynchttpclient.RequestBuilder
 import org.slf4j.LoggerFactory
@@ -26,7 +26,7 @@ trait OnrClient {
   def getPerustiedotByHetus(personOids: Set[String]): Future[Seq[OnrHenkiloPerustiedot]]
 }
 
-class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String) extends OnrClient {
+class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries: Int = 3, onrRetryDelayMillis: Long = 10000) extends OnrClient {
 
   val LOG = LoggerFactory.getLogger(classOf[OnrClientImpl]);
 
@@ -110,58 +110,71 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String) extends On
   }
 
   private def doPost(url: String, body: Object): Future[String] = {
-    val req = new RequestBuilder()
-      .setMethod("POST")
-      .setHeader("Content-Type", "application/json")
-      .setBody(mapper.writeValueAsString(body))
-      .setUrl(url)
-      .build()
-    try {
-      asScala(casClient.execute(req)).map {
-        case r if r.getStatusCode == 200 =>
-          r.getResponseBody()
-        case r =>
-          val errorStr = s"Haku oppijanumerorekisteristä epäonnistui: ${r.getStatusCode} ${r.getStatusText} ${r.getResponseBody()}"
-          LOG.error(
-            errorStr
-          )
-          throw new RuntimeException(errorStr)
-      }
-    } catch {
-      case e: Throwable =>
-        LOG.error(
-          s"Haku oppijanumerorekisteristä epäonnistui", e
-        )
-        Future.failed(e)
-    }
+    Util.retryWithBackoff(
+      operation = {
+        val req = new RequestBuilder()
+          .setMethod("POST")
+          .setHeader("Content-Type", "application/json")
+          .setBody(mapper.writeValueAsString(body))
+          .setUrl(url)
+          .build()
+        try {
+          asScala(casClient.execute(req)).map {
+            case r if r.getStatusCode == 200 =>
+              r.getResponseBody()
+            case r if r.getStatusCode >= 500 =>
+              val errorStr = s"Haku oppijanumerorekisteristä epäonnistui: ${r.getStatusCode} ${r.getStatusText} ${r.getResponseBody()}"
+              LOG.error(errorStr)
+              throw new RuntimeException(errorStr)
+            case r =>
+              val errorStr = s"Haku oppijanumerorekisteristä epäonnistui: ${r.getStatusCode} ${r.getStatusText} ${r.getResponseBody()}"
+              LOG.error(errorStr)
+              throw new NonRetriableException(errorStr)
+          }
+        } catch {
+          case e: Throwable =>
+            LOG.error(s"Haku oppijanumerorekisteristä epäonnistui", e)
+            Future.failed(e)
+        }
+      },
+      retries = onrRetries,
+      retryDelayMillis = onrRetryDelayMillis,
+      failMessage = s"ONR POST-kutsu epäonnistui: $url"
+    )
   }
 
   private def doGet(url: String): Future[Option[String]] = {
-
     LOG.info(s"haetaan, $url")
-    val req = new RequestBuilder()
-      .setMethod("GET")
-      .setUrl(url)
-      .build()
-    try {
-      asScala(casClient.execute(req)).map {
-        case r if r.getStatusCode == 200 =>
-          Some(r.getResponseBody())
-        case r if r.getStatusCode == 404 =>
-          None
-        case r =>
-          val errorStr = s"Haku oppijanumerorekisteristä epäonnistui: ${r.getStatusCode} ${r.getStatusText} ${r.getResponseBody()}"
-          LOG.error(
-            errorStr
-          )
-          throw new RuntimeException(errorStr)
-      }
-    } catch {
-      case e: Throwable =>
-        LOG.error(
-          s"Haku oppijanumerorekisteristä epäonnistui", e
-        )
-        Future.failed(e)
-    }
+    Util.retryWithBackoff(
+      operation = {
+        val req = new RequestBuilder()
+          .setMethod("GET")
+          .setUrl(url)
+          .build()
+        try {
+          asScala(casClient.execute(req)).map {
+            case r if r.getStatusCode == 200 =>
+              Some(r.getResponseBody())
+            case r if r.getStatusCode == 404 =>
+              None
+            case r if r.getStatusCode >= 500 =>
+              val errorStr = s"Haku oppijanumerorekisteristä epäonnistui: ${r.getStatusCode} ${r.getStatusText} ${r.getResponseBody()}"
+              LOG.error(errorStr)
+              throw new RuntimeException(errorStr)
+            case r =>
+              val errorStr = s"Haku oppijanumerorekisteristä epäonnistui: ${r.getStatusCode} ${r.getStatusText} ${r.getResponseBody()}"
+              LOG.error(errorStr)
+              throw new NonRetriableException(errorStr)
+          }
+        } catch {
+          case e: Throwable =>
+            LOG.error(s"Haku oppijanumerorekisteristä epäonnistui", e)
+            Future.failed(e)
+        }
+      },
+      retries = onrRetries,
+      retryDelayMillis = onrRetryDelayMillis,
+      failMessage = s"ONR GET-kutsu epäonnistui: $url"
+    )
   }
 }

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/client/OnrClient.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/client/OnrClient.scala
@@ -18,15 +18,17 @@ case class Henkiloviite(henkiloOid: String, masterOid: String) {
   def bothOids: Set[String] = Set(henkiloOid, masterOid)
 }
 
+case class RetryConfig(retries: Int = 3, retryDelayMillis: Long = 5000)
+
 trait OnrClient {
-  def getHenkiloviitteetForHenkilot(personOids: Set[String]): Future[Set[Henkiloviite]]
-  def getMasterHenkilosForPersonOids(personOids: Set[String]): Future[Map[String, OnrMasterHenkilo]]
-  def getAsiointikieli(personOid: String): Future[Option[String]]
-  def getPerustiedotByPersonOids(personOids: Set[String]): Future[Seq[OnrHenkiloPerustiedot]]
-  def getPerustiedotByHetus(personOids: Set[String]): Future[Seq[OnrHenkiloPerustiedot]]
+  def getHenkiloviitteetForHenkilot(personOids: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Set[Henkiloviite]]
+  def getMasterHenkilosForPersonOids(personOids: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Map[String, OnrMasterHenkilo]]
+  def getAsiointikieli(personOid: String, retryConfig: RetryConfig = RetryConfig()): Future[Option[String]]
+  def getPerustiedotByPersonOids(personOids: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Seq[OnrHenkiloPerustiedot]]
+  def getPerustiedotByHetus(personOids: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Seq[OnrHenkiloPerustiedot]]
 }
 
-class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries: Int = 3, onrRetryDelayMillis: Long = 10000) extends OnrClient {
+class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String) extends OnrClient {
 
   val LOG = LoggerFactory.getLogger(classOf[OnrClientImpl]);
 
@@ -37,7 +39,7 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries
 
   val onrBatchSize = 5000
 
-  override def getMasterHenkilosForPersonOids(henkiloOids: Set[String]): Future[Map[String, OnrMasterHenkilo]] = {
+  override def getMasterHenkilosForPersonOids(henkiloOids: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Map[String, OnrMasterHenkilo]] = {
     val batches: Seq[(Set[String], Int)] = henkiloOids
       .grouped(onrBatchSize)
       .zipWithIndex
@@ -52,7 +54,7 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries
             s"Haetaan ${chunk._1.size}:n henkilön osaa ${chunk._2 + 1 + "/" + batches.size}"
           )
           val chunkResult: Future[Map[String, OnrMasterHenkilo]] = {
-            doPost(environmentBaseUrl + "/oppijanumerorekisteri-service/henkilo/masterHenkilosByOidList", chunk._1)
+            doPost(environmentBaseUrl + "/oppijanumerorekisteri-service/henkilo/masterHenkilosByOidList", chunk._1, retryConfig)
               .map(result => {
                 val typeRef = new TypeReference[Map[String, OnrMasterHenkilo]] {}
                 mapper.readValue(result, typeRef)
@@ -63,23 +65,23 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries
     }
   }
 
-  override def getPerustiedotByHetus(hetus: Set[String]): Future[Seq[OnrHenkiloPerustiedot]] = {
-    doPost(environmentBaseUrl + "/oppijanumerorekisteri-service/henkilo/henkiloPerustietosByHenkiloHetuList", hetus)
+  override def getPerustiedotByHetus(hetus: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Seq[OnrHenkiloPerustiedot]] = {
+    doPost(environmentBaseUrl + "/oppijanumerorekisteri-service/henkilo/henkiloPerustietosByHenkiloHetuList", hetus, retryConfig)
       .map(result => {
         val typeRef = new TypeReference[Seq[OnrHenkiloPerustiedot]] {}
         mapper.readValue(result, typeRef)
       })
   }
 
-  override def getPerustiedotByPersonOids(personOids: Set[String]): Future[Seq[OnrHenkiloPerustiedot]] = {
-    doPost(environmentBaseUrl + "/oppijanumerorekisteri-service/henkilo/henkiloPerustietosByHenkiloOidList", personOids)
+  override def getPerustiedotByPersonOids(personOids: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Seq[OnrHenkiloPerustiedot]] = {
+    doPost(environmentBaseUrl + "/oppijanumerorekisteri-service/henkilo/henkiloPerustietosByHenkiloOidList", personOids, retryConfig)
       .map(result => {
         val typeRef = new TypeReference[Seq[OnrHenkiloPerustiedot]] {}
         mapper.readValue(result, typeRef)
       })
   }
 
-  override def getHenkiloviitteetForHenkilot(henkiloOids: Set[String]): Future[Set[Henkiloviite]] = {
+  override def getHenkiloviitteetForHenkilot(henkiloOids: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Set[Henkiloviite]] = {
     val batches: Seq[(Set[String], Int)] = henkiloOids.grouped(onrBatchSize).zipWithIndex.toList
 
     val allResults: Future[Set[Henkiloviite]] = batches.foldLeft(Future(Set[Henkiloviite]())) {
@@ -90,7 +92,7 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries
           )
           val queryObject: Map[String, Set[String]] = Map("henkiloOids" -> chunk._1)
           val chunkResult: Future[Set[Henkiloviite]] = {
-            doPost(environmentBaseUrl + "/oppijanumerorekisteri-service/s2s/duplicateHenkilos", queryObject)
+            doPost(environmentBaseUrl + "/oppijanumerorekisteri-service/s2s/duplicateHenkilos", queryObject, retryConfig)
               .map(result => {
                 LOG.info(s"Saatiin tulos: $result")
                 val typeRef = new TypeReference[List[Henkiloviite]] {}
@@ -105,17 +107,18 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries
     allResults
   }
 
-  override def getAsiointikieli(personOid: String): Future[Option[String]] = {
-    doGet(s"$environmentBaseUrl/oppijanumerorekisteri-service/henkilo/$personOid/asiointiKieli")
+  override def getAsiointikieli(personOid: String, retryConfig: RetryConfig = RetryConfig()): Future[Option[String]] = {
+    doGet(s"$environmentBaseUrl/oppijanumerorekisteri-service/henkilo/$personOid/asiointiKieli", retryConfig)
   }
 
-  private def doPost(url: String, body: Object): Future[String] = {
+  private def doPost(url: String, body: Object, retryConfig: RetryConfig): Future[String] = {
+    val serializedBody = mapper.writeValueAsString(body)
     Util.retryWithBackoff(
       operation = {
         val req = new RequestBuilder()
           .setMethod("POST")
           .setHeader("Content-Type", "application/json")
-          .setBody(mapper.writeValueAsString(body))
+          .setBody(serializedBody)
           .setUrl(url)
           .build()
         try {
@@ -137,13 +140,13 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries
             Future.failed(e)
         }
       },
-      retries = onrRetries,
-      retryDelayMillis = onrRetryDelayMillis,
+      retries = retryConfig.retries,
+      retryDelayMillis = retryConfig.retryDelayMillis,
       failMessage = s"ONR POST-kutsu epäonnistui: $url"
     )
   }
 
-  private def doGet(url: String): Future[Option[String]] = {
+  private def doGet(url: String, retryConfig: RetryConfig): Future[Option[String]] = {
     LOG.info(s"haetaan, $url")
     Util.retryWithBackoff(
       operation = {
@@ -172,8 +175,8 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String, onrRetries
             Future.failed(e)
         }
       },
-      retries = onrRetries,
-      retryDelayMillis = onrRetryDelayMillis,
+      retries = retryConfig.retries,
+      retryDelayMillis = retryConfig.retryDelayMillis,
       failMessage = s"ONR GET-kutsu epäonnistui: $url"
     )
   }

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/client/OnrClient.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/client/OnrClient.scala
@@ -8,6 +8,9 @@ import fi.oph.suorituspalvelu.integration.{NonRetriableException, OnrHenkiloPeru
 import fi.vm.sade.javautils.nio.cas.CasClient
 import org.asynchttpclient.RequestBuilder
 import org.slf4j.LoggerFactory
+
+import java.time.Duration
+import java.time.temporal.{ChronoUnit, TemporalUnit}
 import scala.concurrent.Future
 import scala.jdk.javaapi.FutureConverters.asScala
 
@@ -18,7 +21,7 @@ case class Henkiloviite(henkiloOid: String, masterOid: String) {
   def bothOids: Set[String] = Set(henkiloOid, masterOid)
 }
 
-case class RetryConfig(retries: Int = 3, retryDelayMillis: Long = 5000)
+case class RetryConfig(retries: Int = 3, retryDelayMillis: Long = 5000, requestTimeoutMillis: Int = 60000)
 
 trait OnrClient {
   def getHenkiloviitteetForHenkilot(personOids: Set[String], retryConfig: RetryConfig = RetryConfig()): Future[Set[Henkiloviite]]
@@ -120,6 +123,7 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String) extends On
           .setHeader("Content-Type", "application/json")
           .setBody(serializedBody)
           .setUrl(url)
+          .setRequestTimeout(Duration.of(retryConfig.requestTimeoutMillis, ChronoUnit.MILLIS))
           .build()
         try {
           asScala(casClient.execute(req)).map {
@@ -153,6 +157,7 @@ class OnrClientImpl(casClient: CasClient, environmentBaseUrl: String) extends On
         val req = new RequestBuilder()
           .setMethod("GET")
           .setUrl(url)
+          .setRequestTimeout(Duration.of(retryConfig.requestTimeoutMillis, ChronoUnit.MILLIS))
           .build()
         try {
           asScala(casClient.execute(req)).map {

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/ytr/YtrIntegration.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/integration/ytr/YtrIntegration.scala
@@ -2,7 +2,7 @@ package fi.oph.suorituspalvelu.integration.ytr
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import fi.oph.suorituspalvelu.integration.client.{YtrClient, YtrHetuPostData, YtrMassOperationQueryResponse}
+import fi.oph.suorituspalvelu.integration.client.{RetryConfig, YtrClient, YtrHetuPostData, YtrMassOperationQueryResponse}
 import fi.oph.suorituspalvelu.integration.{OnrIntegration, Util}
 import fi.oph.suorituspalvelu.parsing.ytr.YtrParser
 import fi.oph.suorituspalvelu.util.ZipUtil
@@ -33,6 +33,8 @@ class YtrIntegration {
   @Autowired val ytrClient: YtrClient = null
 
   @Autowired val onrIntegration: OnrIntegration = null
+
+  implicit val onrRetryConfig: RetryConfig = RetryConfig()
 
   @Autowired var database: JdbcBackend.JdbcDatabaseDef = null
 

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/mankeli/HarkinnanvaraisuusService.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/mankeli/HarkinnanvaraisuusService.scala
@@ -214,7 +214,7 @@ class HarkinnanvaraisuusService {
   }
 
   def haeSupaTiedot(personOid: String): Seq[Opiskeluoikeus] = {
-    val allOidsForPerson = Await.result(onrIntegration.getAliasesForPersonOids(Set(personOid)), 10.seconds).allOids
+    val allOidsForPerson = Await.result(onrIntegration.getAliasesForPersonOids(Set(personOid)), 65.seconds).allOids
     allOidsForPerson.flatMap(oid => opiskeluoikeusParsingService.haeSuoritukset(oid, useKoskiSkipTable = true).values.flatten).toSeq
   }
 

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/mankeli/HarkinnanvaraisuusService.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/mankeli/HarkinnanvaraisuusService.scala
@@ -1,7 +1,7 @@
 package fi.oph.suorituspalvelu.mankeli
 
 import fi.oph.suorituspalvelu.business.{KantaOperaatiot, Opiskeluoikeus, PerusopetuksenOpiskeluoikeus, PerusopetuksenOppimaara, PerusopetuksenOppimaaranOppiaineidenSuoritus, SuoritusTila}
-import fi.oph.suorituspalvelu.integration.client.{AtaruValintalaskentaHakemus, HakemuspalveluClient, KoutaHakukohde}
+import fi.oph.suorituspalvelu.integration.client.{AtaruValintalaskentaHakemus, HakemuspalveluClient, KoutaHakukohde, RetryConfig}
 import fi.oph.suorituspalvelu.integration.{OnrIntegration, TarjontaIntegration}
 import fi.oph.suorituspalvelu.parsing.OpiskeluoikeusParsingService
 import org.slf4j.LoggerFactory
@@ -176,6 +176,8 @@ class HarkinnanvaraisuusService {
   @Autowired val onrIntegration: OnrIntegration = null
 
   @Autowired val tarjontaIntegration: TarjontaIntegration = null
+
+  implicit val onrRetryConfig: RetryConfig = RetryConfig(retries = 2, retryDelayMillis = 1000)
 
   private def getHakemuksenHarkinnanvaraisuusValue(
     hakemus: AtaruValintalaskentaHakemus,

--- a/suorituspalvelu-shared/src/test/scala/fi/oph/suorituspalvelu/business/integration/UtilTest.scala
+++ b/suorituspalvelu-shared/src/test/scala/fi/oph/suorituspalvelu/business/integration/UtilTest.scala
@@ -1,6 +1,6 @@
 package fi.oph.suorituspalvelu.business.integration
 
-import fi.oph.suorituspalvelu.integration.Util
+import fi.oph.suorituspalvelu.integration.{NonRetriableException, Util}
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.{Assertions, Test, TestInstance}
 
@@ -39,6 +39,23 @@ class UtilTest {
     )
     Assertions.assertEquals("success", result)
     Assertions.assertEquals(3, attempts.get())
+  }
+
+  @Test def testRetryWithBackoff_nonRetriableExceptionIsNotRetried(): Unit = {
+    val attempts = new AtomicInteger(0)
+    def operation = Future {
+      attempts.incrementAndGet()
+      throw new NonRetriableException("client error")
+    }
+
+    val exception = Assertions.assertThrows(classOf[NonRetriableException], () => {
+      Await.result(
+        Util.retryWithBackoff(operation, retries = 3, retryDelayMillis = 10),
+        5.seconds
+      )
+    })
+    Assertions.assertEquals("client error", exception.getMessage)
+    Assertions.assertEquals(1, attempts.get())
   }
 
   @Test def testRetryWithBackoff_failsAfterAllRetriesExhausted(): Unit = {


### PR DESCRIPTION
## Ongelma

YTR- ja VIRTA-eräajot kutsuvat oppijanumerorekisteriä (ONR) suurilla henkilöjoukolla. ONR on viime aikoina ajoittain vastannut hitaasti tai ei lainkaan, jolloin kutsut ovat päätyneet aikakatkaisuun ja koko eräajo on epäonnistunut.

## Ratkaisu

Lisätään uudelleenyrityslogiikka kaikkiin ONR:n HTTP-kutsuihin ja tehdään retry-asetukset konfiguroitavaksi kutsupäässä — näin UI-kutsuille ja yöllisille eräajoille voi asettaa erilaiset arvot.

### Muutokset

**`Util.scala`**
- Uusi `NonRetriableException`-luokka virheille joita ei pidä retrytä
- `retryWithBackoff` päivitetty: `NonRetriableException` heitetään läpi heti ilman retryä

**`OnrClient.scala`**
- Uusi `case class RetryConfig(retries: Int = 3, retryDelayMillis: Long = 5000)`
- Kaikki `OnrClient`-traitin metodit saavat `retryConfig: RetryConfig = RetryConfig()` -parametrin
- `OnrClientImpl`:n konstruktoriparametrit `onrRetries`/`onrRetryDelayMillis` poistettu — retry-asetukset välitetään nyt per-kutsu
- `doPost` ja `doGet` kääritty `Util.retryWithBackoff`:iin: 5xx-vastaukset retriataan, 4xx-vastaukset epäonnistuvat välittömästi `NonRetriableException`:lla
- Body serialisoidaan ennen retry-silmukkaa, jolloin serialisointivirhe epäonnistuu heti eikä sitä retriata

**`OnrIntegration.scala`**
- Kaikki traitin metodit saavat curried implicit -parametrin: `(implicit retryConfig: RetryConfig)`

Kukin kutsuva luokka ylikirjoittaa oletuksen omalla `implicit val onrRetryConfig`:lla käyttötarkoituksen mukaan:

| Luokka | Arvo | Perustelu |
|--------|------|-----------|
| `UIResource`, `UIService` | `RetryConfig(retries = 0)` | Ei retryjä UI-kutsuissa |
| `VirtaService`, `ValintaDataService` | `RetryConfig(retryDelayMillis = 5000)` | Pidempi viive eräajoissa |
| `HakukelpoisuusService`, `LahtokoulutService`, `HarkinnanvaraisuusService`, `YtrIntegration` | `RetryConfig()` | Oletusarvo |

### Testit

- `OnrClientRetryTest` (uusi, 9 testiä): testaa `OnrClientImpl`:iä suoraan mockaten `CasClient`:iä. Kattaa yhteyshäiriöretryt, 5xx-retryt, 4xx- ja 404-ei-retryä sekä onnistumisen ensimmäisellä yrityksellä — sekä POST- että GET-polulle.
- `UtilTest`: uusi testi varmistaa että `NonRetriableException` ohittaa retry-silmukan
- `BaseIntegraatioTesti`: lisätty `implicit val onrRetryConfig = RetryConfig(retries = 0, retryDelayMillis = 1)` — integraatiotesteissä ei odotella retryjä
- Kaikki integraatiotestit päivitetty: `OnrIntegration`-mock-kutsut muutettu muotoon `onrIntegration.metodi(eqTo(arg))(any[RetryConfig]())` Mockiton matcher-säännön vuoksi