### PR TITLE
OY-5669: Huomioi myös paikalliset perusopetuksen valinnaiset arvosanat Koski-parsinnassa

### DIFF
--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/business/ParserVersions.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/business/ParserVersions.scala
@@ -7,7 +7,7 @@ package fi.oph.suorituspalvelu.business
  * niin että se vaikuttaa lopputulokseen.
  */
 object ParserVersions {
-  val KOSKI = 10
+  val KOSKI = 11
   val VIRTA = 7
   val YTR = 2
   val SYOTETTY_PERUSOPETUS = 1

--- a/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/parsing/koski/KoskiUtil.scala
+++ b/suorituspalvelu-shared/src/main/scala/fi/oph/suorituspalvelu/parsing/koski/KoskiUtil.scala
@@ -47,9 +47,10 @@ object KoskiUtil {
 
   def includePerusopetuksenOppiaine(osaSuoritus: KoskiOsaSuoritus, pakollistenKoodit: Set[String], koodistoProvider: KoodistoProvider): Boolean = {
     val oppiaineKoodi = osaSuoritus.koulutusmoduuli.get.tunniste.get.koodiarvo
+    val oppiaineKoodistoUri = osaSuoritus.koulutusmoduuli.get.tunniste.get.koodistoUri
 
     val hasArviointi = osaSuoritus.arviointi.isDefined
-    val isKoulukohtainen = !koodistoProvider.haeKoodisto(KOODISTO_OPPIAINEET).contains(oppiaineKoodi)
+    val isKoulukohtainen = !koodistoProvider.haeKoodisto(KOODISTO_OPPIAINEET).contains(oppiaineKoodi) || oppiaineKoodistoUri != KOODISTO_OPPIAINEET
     val aineTiedossa = !"XX".equals(oppiaineKoodi)
     val pakollinen = osaSuoritus.koulutusmoduuli.exists(km => km.pakollinen.exists(p => p))
     val sisallytettavaEiPakollinenKieli = sisallytettavatEiPakollisetKielet.contains(oppiaineKoodi)

--- a/suorituspalvelu-shared/src/test/scala/fi/oph/suorituspalvelu/business/parsing/koski/KoskiUtilTest.scala
+++ b/suorituspalvelu-shared/src/test/scala/fi/oph/suorituspalvelu/business/parsing/koski/KoskiUtilTest.scala
@@ -108,11 +108,11 @@ class KoskiUtilTest {
       tunnetutOppiaineet.map(k => k -> null.asInstanceOf[fi.oph.suorituspalvelu.integration.client.Koodi]).toMap
     else Map.empty
 
-  private def mkOsa(koodi: String, pakollinen: Boolean, laajuus: Option[BigDecimal], hasArviointi: Boolean): KoskiOsaSuoritus =
+  private def mkOsa(koodi: String, pakollinen: Boolean, laajuus: Option[BigDecimal], hasArviointi: Boolean, koodistoUri: String = "koskioppiaineetyleissivistava"): KoskiOsaSuoritus =
     KoskiOsaSuoritus(
       tyyppi = null,
       koulutusmoduuli = Some(KoskiKoulutusModuuli(
-        tunniste = Some(KoskiKoodi(koodi, "koskioppiaineetyleissivistava", None, Kielistetty(None, None, None), None)),
+        tunniste = Some(KoskiKoodi(koodi, koodistoUri, None, Kielistetty(None, None, None), None)),
         koulutustyyppi = None,
         laajuus = laajuus.map(arvo => KoskiLaajuus(arvo, None)),
         kieli = None,
@@ -140,6 +140,13 @@ class KoskiUtilTest {
     Assertions.assertFalse(KoskiUtil.includePerusopetuksenOppiaine(
       mkOsa("KOULUKOHTAINEN_X", pakollinen = true, laajuus = Some(BigDecimal(3)), hasArviointi = true),
       Set("KOULUKOHTAINEN_X"),
+      oppiaineKoodistoProvider))
+
+  @Test def testIncludePerusopetuksenOppiainePaikallinenValinnainen(): Unit =
+    // paikallinen valinnainen: koodiarvo löytyy koodistosta mutta koodistoUri on paikallinen -> ei mukaan
+    Assertions.assertFalse(KoskiUtil.includePerusopetuksenOppiaine(
+      mkOsa("MA", pakollinen = false, laajuus = Some(BigDecimal(3)), hasArviointi = true, koodistoUri = "painotus"),
+      Set("MA"),
       oppiaineKoodistoProvider))
 
   @Test def testIncludePerusopetuksenOppiaineXXEiTiedossa(): Unit =


### PR DESCRIPTION
## Ongelma

Koski-parsinnassa perusopetuksen valinnainen aine tulkittiin virheellisesti kansalliseksi oppiaineeksi, jos sen koodiarvo löytyi kansallisesta koodistosta — vaikka `koodistoUri` viittasi paikalliseen koodistoon (esim. `"painotus"`). Tällöin paikallinen valinnainen aine saatettiin sisällyttää parsinta-tulokseen väärin.

## Ratkaisu

`isKoulukohtainen`-tarkistukseen lisätty ehto: aine on koulukohtainen myös silloin, kun sen `koodistoUri` ei ole `koskioppiaineetyleissivistava` — vaikka koodiarvo löytyisikin kansallisesta koodistosta.

Koski-parserin versio bumpattu 10 → 11, koska muutos vaikuttaa parsinta-outputiin.